### PR TITLE
[WIP] Spike for basic models and type/query graphql definitions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development, :test do
   # Use sqlite3 as the database for Active Record
   gem 'sqlite3'
   gem 'rspec-rails'
+  gem 'awesome_print'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
+    awesome_print (1.8.0)
     bindex (0.5.0)
     bootsnap (1.3.0)
       msgpack (~> 1.0)
@@ -215,6 +216,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  awesome_print
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15, < 4.0)

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,4 +1,5 @@
 class GraphqlController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: :execute
   def execute
     variables = ensure_hash(params[:variables])
     query = params[:query]

--- a/app/graphql/cocktail_yeti_schema.rb
+++ b/app/graphql/cocktail_yeti_schema.rb
@@ -1,4 +1,5 @@
 CocktailYetiSchema = GraphQL::Schema.define do
+  max_complexity(400)
   mutation(Types::MutationType)
   query(Types::QueryType)
 end

--- a/app/graphql/types/cocktail_type.rb
+++ b/app/graphql/types/cocktail_type.rb
@@ -1,0 +1,13 @@
+Types::CocktailType = GraphQL::ObjectType.define do
+  name "Cocktail"
+  description "Top level representation of a cocktail"
+  field :name, types.String
+  field :cocktail_type, types.String
+  field :glass, types.String
+  field :recipes do
+    type types[Types::RecipeType]
+    resolve -> (cocktail, args, ctx) {
+      cocktail.recipes
+    }
+  end
+end

--- a/app/graphql/types/ingredient_type.rb
+++ b/app/graphql/types/ingredient_type.rb
@@ -1,0 +1,11 @@
+Types::IngredientType = GraphQL::ObjectType.define do
+  name "Ingredient"
+  field :name, types.String
+  field :generic_name, types.String
+  field :recipes do
+    type types[Types::RecipeType]
+    resolve -> (ingredient, args, ctx) {
+      ingredient.recipes
+    }
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -11,8 +11,11 @@ Types::QueryType = GraphQL::ObjectType.define do
     type types[Types::CocktailType]
     argument :id, types.ID
     argument :name, types.String
+    argument :random, types.Boolean, default_value: false
     resolve -> (obj, args, ctx) {
-      if args[:name]
+      if args[:random]
+        [Cocktail.order("RANDOM()").first]
+      elsif args[:name]
         Cocktail.find_by_name(args[:name])
       elsif args[:id]
         Cocktail.find(args[:id])

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -3,11 +3,33 @@ Types::QueryType = GraphQL::ObjectType.define do
   # Add root-level fields here.
   # They will be entry points for queries on your schema.
 
-  # TODO: remove me
-  field :testField, types.String do
-    description "An example field added by the generator"
-    resolve ->(obj, args, ctx) {
-      "Hello World!"
+  field :cocktails do
+    type types[Types::CocktailType]
+    argument :id, types.ID
+    argument :name, types.String
+    resolve -> (obj, args, ctx) {
+      if args[:name]
+        Cocktail.find_by_name(args[:name])
+      elsif args[:id]
+        Cocktail.find(args[:id])
+      else
+        Cocktail.first(10)
+      end
+    }
+  end
+
+  field :ingredient do
+    type Types::IngredientType
+    argument :id, types.ID
+    argument :name, types.String
+    resolve -> (obj, args, ctx) {
+      if args[:name]
+        Ingredient.find_by_name(args[:name])
+      elsif args[:id]
+        Ingredient.find(args[:id])
+      else
+        Ingredient.first(10)
+      end
     }
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -3,6 +3,10 @@ Types::QueryType = GraphQL::ObjectType.define do
   # Add root-level fields here.
   # They will be entry points for queries on your schema.
 
+  field :ping, types.String do
+    resolve ->(obj, args, ctx) { "pong" }
+  end
+
   field :cocktails do
     type types[Types::CocktailType]
     argument :id, types.ID

--- a/app/graphql/types/recipe_ingredient_type.rb
+++ b/app/graphql/types/recipe_ingredient_type.rb
@@ -1,0 +1,7 @@
+Types::RecipeIngredientType = GraphQL::ObjectType.define do
+  name "RecipeIngredient"
+  description "Represents the use of an Ingredient in a recipe"
+  field :ingredient_use, types.String
+  field :amount, types.String
+  field :ingredient, Types::IngredientType
+end

--- a/app/graphql/types/recipe_ingredient_type.rb
+++ b/app/graphql/types/recipe_ingredient_type.rb
@@ -3,5 +3,6 @@ Types::RecipeIngredientType = GraphQL::ObjectType.define do
   description "Represents the use of an Ingredient in a recipe"
   field :ingredient_use, types.String
   field :amount, types.String
+  field :ingredient_name, types.String
   field :ingredient, Types::IngredientType
 end

--- a/app/graphql/types/recipe_type.rb
+++ b/app/graphql/types/recipe_type.rb
@@ -1,0 +1,13 @@
+Types::RecipeType = GraphQL::ObjectType.define do
+  name "Recipe"
+  description "Contains a collection of Ingredients through RecipeIngredients"
+  field :source, types.String
+  field :directions, types.String
+  field :cocktail, Types::CocktailType
+  field :recipe_ingredients do
+    type types[Types::RecipeIngredientType]
+    resolve -> (recipe, args, ctx) {
+      recipe.recipe_ingredients
+    }
+  end
+end

--- a/app/models/cocktail.rb
+++ b/app/models/cocktail.rb
@@ -1,0 +1,2 @@
+class Cocktail < ApplicationRecord
+end

--- a/app/models/cocktail.rb
+++ b/app/models/cocktail.rb
@@ -1,2 +1,3 @@
 class Cocktail < ApplicationRecord
+  has_many :recipes
 end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,0 +1,3 @@
+class Ingredient < ApplicationRecord
+  belongs_to :recipe
+end

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,3 +1,4 @@
 class Ingredient < ApplicationRecord
-  belongs_to :recipe
+  has_many :recipe_ingredients
+  has_many :recipes, through: :recipe_ingredients
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,3 +1,6 @@
 class Recipe < ApplicationRecord
   belongs_to :cocktail
+
+  has_many :recipe_ingredients
+  has_many :ingredients, through: :recipe_ingredients
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,0 +1,3 @@
+class Recipe < ApplicationRecord
+  belongs_to :cocktail
+end

--- a/app/models/recipe_ingredient.rb
+++ b/app/models/recipe_ingredient.rb
@@ -1,0 +1,4 @@
+class RecipeIngredient < ApplicationRecord
+  belongs_to :recipe
+  belongs_to :ingredient
+end

--- a/app/models/recipe_ingredient.rb
+++ b/app/models/recipe_ingredient.rb
@@ -1,4 +1,8 @@
 class RecipeIngredient < ApplicationRecord
   belongs_to :recipe
   belongs_to :ingredient
+
+  def ingredient_name
+    self.ingredient.name
+  end
 end

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,2 +1,2 @@
 <h1>Welcome to the Cocktail Yeti!</h1>
-<p>This is a GraphQL Cocktail API. You can get started with a POST to <a href="<%= request.url %>graphql" data-method="post"><%= request.url %>graphql</a></p>
+<p>This is a GraphQL Cocktail API. You can get started with a POST to <a href="<%= request.url %>graphql?query={cocktails{name}}" data-method="post"><%= request.url %>graphql</a></p>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,2 +1,3 @@
 <h1>Welcome to the Cocktail Yeti!</h1>
-<p>This is a GraphQL Cocktail API. You can get started with a POST to <a href="<%= request.url %>graphql?query={cocktails{name}}" data-method="post"><%= request.url %>graphql</a></p>
+<p>This is a GraphQL Cocktail API. You can get started with a POST to <a href="<%= request.url %>graphql?query={ping}" data-method="post"><%= request.url %>graphql</a></p>
+<p>Click  <a href="<%= request.url %>graphql?query={cocktails(random:true){name,recipes{recipe_ingredients{ingredient_name,amount,ingredient_use},source}}}" data-method="post">this link</a> to render a random cocktail</p>

--- a/db/migrate/20180514232805_create_cocktails.rb
+++ b/db/migrate/20180514232805_create_cocktails.rb
@@ -1,0 +1,11 @@
+class CreateCocktails < ActiveRecord::Migration[5.2]
+  def change
+    create_table :cocktails do |t|
+      t.string :name
+      t.string :cocktail_type
+      t.string :glass
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180514232909_create_recipes.rb
+++ b/db/migrate/20180514232909_create_recipes.rb
@@ -3,6 +3,7 @@ class CreateRecipes < ActiveRecord::Migration[5.2]
     create_table :recipes do |t|
       t.references :cocktail, foreign_key: true
       t.string :source
+      t.string :directions
 
       t.timestamps
     end

--- a/db/migrate/20180514232909_create_recipes.rb
+++ b/db/migrate/20180514232909_create_recipes.rb
@@ -1,0 +1,10 @@
+class CreateRecipes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :recipes do |t|
+      t.references :cocktail, foreign_key: true
+      t.string :source
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180514233003_create_ingredients.rb
+++ b/db/migrate/20180514233003_create_ingredients.rb
@@ -1,0 +1,13 @@
+class CreateIngredients < ActiveRecord::Migration[5.2]
+  def change
+    create_table :ingredients do |t|
+      t.references :recipe, foreign_key: true
+      t.string :name
+      t.string :generic_name
+      t.string :ingredient_use
+      t.string :amount
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180514233003_create_ingredients.rb
+++ b/db/migrate/20180514233003_create_ingredients.rb
@@ -1,11 +1,8 @@
 class CreateIngredients < ActiveRecord::Migration[5.2]
   def change
     create_table :ingredients do |t|
-      t.references :recipe, foreign_key: true
       t.string :name
       t.string :generic_name
-      t.string :ingredient_use
-      t.string :amount
 
       t.timestamps
     end

--- a/db/migrate/20180515003355_create_recipe_ingredient.rb
+++ b/db/migrate/20180515003355_create_recipe_ingredient.rb
@@ -1,0 +1,10 @@
+class CreateRecipeIngredient < ActiveRecord::Migration[5.2]
+  def change
+    create_table :recipe_ingredients do |t|
+      t.belongs_to :recipe, foreign_key: true
+      t.belongs_to :ingredient, foreign_key: true
+      t.string :ingredient_use
+      t.string :amount
+    end
+  end
+end

--- a/db/migrate/20180515003715_add_recipe_ingredient_index_to_recipe_ingredients.rb
+++ b/db/migrate/20180515003715_add_recipe_ingredient_index_to_recipe_ingredients.rb
@@ -1,0 +1,6 @@
+class AddRecipeIngredientIndexToRecipeIngredients < ActiveRecord::Migration[5.2]
+  def change
+    add_index :recipe_ingredients, [:ingredient_id, :recipe_id]
+    add_index :recipe_ingredients, [:recipe_id, :ingredient_id]
+  end
+end

--- a/db/pdt_seed.csv
+++ b/db/pdt_seed.csv
@@ -1,0 +1,1636 @@
+Drink,Ingredient,Amount,IngredientUse,Glass,HowToMix
+212,Partida Reposado Tequila,2oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+212,Ruby Red Grapefruit Juice,2oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+212,Aperol,1oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+212,Orange Twist,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+#3 Cup,Mint Leaf,4-5,Muddle,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+#3 Cup,Cucumber Slice,2,Muddle,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+#3 Cup,Orange Slice,2,Muddle,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+#3 Cup,Hine V.S.O.P. Cognac,1oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+#3 Cup,House Ginger Beer,1oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+#3 Cup,Mint Sprig,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+#3 Cup,Martini Sweet Vermouth,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+#3 Cup,Cherry Heering,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+#3 Cup,Lemon Juice,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+#3 Cup,Marie Brizard Orange Curacao,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+#8,Don Julio Reposado Tequila,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+#8,House Orange Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+#8,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+#8,Lustau Palo Cortado Sherry,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+#8,Barenjager Honey Liqueur,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+100 Year Punch,Fee Brothers Old Fashion Bitters,2dashes,Build,Rocks,Stir with ice and fine-strain into a chilled rocks glass filled with ice
+100 Year Punch,"Bek Se Ju ""100-year wine""",1oz,Build,Rocks,Stir with ice and fine-strain into a chilled rocks glass filled with ice
+100 Year Punch,Elijah Craig 12-Year-Old Bourbon,1oz,Build,Rocks,Stir with ice and fine-strain into a chilled rocks glass filled with ice
+100 Year Punch,Q Tonic,1oz,Top,Rocks,Stir with ice and fine-strain into a chilled rocks glass filled with ice
+100 Year Punch,Pinch Grated Nutmeg,1,Garnish,Rocks,Stir with ice and fine-strain into a chilled rocks glass filled with ice
+100 Year Punch,Tangerine Zest,1,Garnish,Rocks,Stir with ice and fine-strain into a chilled rocks glass filled with ice
+100 Year Punch,Ssal-Yut Rice Syrup,.25oz,Build,Rocks,Stir with ice and fine-strain into a chilled rocks glass filled with ice
+20th Century,Plymouth Gin,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+20th Century,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+20th Century,Lillet Blanc,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+20th Century,Marie Brizard White Creme de Cacao,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+21st Century,Siete Leguas Blanco Tequila,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+21st Century,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+21st Century,Marie Brizard White Creme de Cacao,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+21st Century,Pernod,,Rinse,Coupe,Shake with ice and strain into a chilled coupe
+Absinthe Drip,Ice-Cold Filtered Water,4.5-6oz,Build,Absinthe,"Pour absinthe into a chilled absinthe glass. Place an absinthe spoon over the rim and set a sugar cube on top. Using an absinthe fountain or water carafe, slowly pour or drip ice-cold water over sugar cube into the glass"
+Absinthe Drip,Vieux Pontarlier Absinthe,1.5oz,Build,Absinthe,"Pour absinthe into a chilled absinthe glass. Place an absinthe spoon over the rim and set a sugar cube on top. Using an absinthe fountain or water carafe, slowly pour or drip ice-cold water over sugar cube into the glass"
+Absinthe Drip,Sugar Cube,1,Build,Absinthe,"Pour absinthe into a chilled absinthe glass. Place an absinthe spoon over the rim and set a sugar cube on top. Using an absinthe fountain or water carafe, slowly pour or drip ice-cold water over sugar cube into the glass"
+Against All Odds Cocktail,Bushmills Irish Whiskey,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Against All Odds Cocktail,Channing Daughters Scuttlehole Chardonnay,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Against All Odds Cocktail,Pansy Flower,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Against All Odds Cocktail,Rothman & Winter Orchard Apricot,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Against All Odds Cocktail,Rhum Clement Creole Shrubb,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Against All Odds Cocktail,Illegal Reposado Mezcal,,Rinse,Coupe,Stir with ice and strain into a chilled coupe
+Aguila Azteca,Honeydew Melon Juice,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Aguila Azteca,Jose Cuervo Tradicional Tequila,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Aguila Azteca,Canton Ginger Liqueur,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Aguila Azteca,Rothman & Winter Creme de Violette,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Airmail,Banks 5 Island Rum,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Airmail,Moet Imperial Champagne,1oz,Top,Coupe,Shake with ice and strain into a chilled coupe
+Airmail,Lime Wheel,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Airmail,Honey Syrup,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Airmail,Lime Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Albert Mathieu,Regan's Orange Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Albert Mathieu,St. Germain Elderflower Liqueur,1barspoon,Build,Coupe,Stir with ice and strain into a chilled coupe
+Albert Mathieu,Plymouth Gin,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Albert Mathieu,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Albert Mathieu,Green Chartreuse,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Albert Mathieu,Lillet Blanc,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Algonquin,Rittenhouse Bonded Rye Whiskey,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Algonquin,Dolin Dry Vermouth,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Algonquin,Pineapple Juice,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Americano Highball,Club Soda,2.5oz,Top,Collins,Build in a chilled Collins glass
+Americano Highball,Campari,1.5oz,Build,Collins,Build in a chilled Collins glass
+Americano Highball,Carpano Antica Sweet Vermouth,1.5oz,Build,Collins,Build in a chilled Collins glass
+Americano Highball,Half an Orange Wheel,1,Garnish,Collins,Build in a chilled Collins glass
+Aperol Spritz,Aperol,2oz,Build,Rocks,"Add everything to a chilled rocks glass, then fill with ice"
+Aperol Spritz,Carpene Malvolti Prosecco,1oz,Build,Rocks,"Add everything to a chilled rocks glass, then fill with ice"
+Aperol Spritz,Club Soda,1oz,Build,Rocks,"Add everything to a chilled rocks glass, then fill with ice"
+Aperol Spritz,Half an Orange Wheel,1,Garnish,Rocks,"Add everything to a chilled rocks glass, then fill with ice"
+Aperol Spritz,Orange Juice,.5oz,Build,Rocks,"Add everything to a chilled rocks glass, then fill with ice"
+Apple Daiquiri,Flor de Cana Silver Dry Rum,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Apple Daiquiri,Lime Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Apple Daiquiri,Schonauer Apfel Schnapps,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Apple Daiquiri,Simple Syrup,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Apple Malt Toddy,Red Jacket Orchards Apple Cider,2oz,Build,Mug,Heat everything and served in a pre-warmed heatproof mug
+Apple Malt Toddy,Drouhin Pommeau,1oz,Build,Mug,Heat everything and served in a pre-warmed heatproof mug
+Apple Malt Toddy,Deep Mountain Grade B Maple Syrup,1barspoon,Build,Mug,Heat everything and served in a pre-warmed heatproof mug
+Apple Malt Toddy,Chivas Regal 12-Year-Old Blended Scotch Whiskey,1.5oz,Build,Mug,Heat everything and served in a pre-warmed heatproof mug
+Apple Malt Toddy,Cinnamon Stick,1,Garnish,Mug,Heat everything and served in a pre-warmed heatproof mug
+Apple Malt Toddy,St. Elizabeth Allspice Dram,.25oz,Build,Mug,Heat everything and served in a pre-warmed heatproof mug
+Applejack Rabbit,Laird's Bonded Apple Brandy,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Applejack Rabbit,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Applejack Rabbit,Orange Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Applejack Rabbit,Deep Mountain Grade B Maple Syrup,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Apricot Flip,Hine V.S.O.P. Cognac,2oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Apricot Flip,Pinch Grated Nutmeg,1,Garnish,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Apricot Flip,Whole Egg,1,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Apricot Flip,Rothman & Winter Orchard Apricot,.75oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Apricot Flip,Simple Syrup,.5oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Archangel,Plymouth Gin,2.25oz,Build,Coupe,Stir with ice and fine-strain into a chilled coupe
+Archangel,Cucumber Slice,2,Muddle,Coupe,Stir with ice and fine-strain into a chilled coupe
+Archangel,Lemon Twist,1,Garnish,Coupe,Stir with ice and fine-strain into a chilled coupe
+Archangel,Aperol,.75oz,Build,Coupe,Stir with ice and fine-strain into a chilled coupe
+Astoria Bianco,House Orange Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Astoria Bianco,Tanqueray Gin,2.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Astoria Bianco,Martini Bianco Vermouth,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Astoria Bianco,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Aviation,Beefeater Gin,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Aviation,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Aviation,Luxardo Maraschino Liqueur,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Aviation,Rothman & Winter Creme de Violette,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Beachbum,Flor de Cana Silver Dry Rum,1oz,Build,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with ice cubes
+Beachbum,Mount Gay Eclipse Amber Rum,1oz,Build,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with ice cubes
+Beachbum,Pineapple Juice,1oz,Build,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with ice cubes
+Beachbum,Orange-Cherry Flag,1,Garnish,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with ice cubes
+Beachbum,Umbrella,1,Garnish,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with ice cubes
+Beachbum,Lime Juice,.75oz,Build,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with ice cubes
+Beachbum,Kassatly Chtaura Orgeat,.5oz,Build,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with ice cubes
+Beachbum,Rothman & Winter Orchard Apricot,.5oz,Build,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with ice cubes
+Beer and a Smoke,Victory Pilsner,6oz,Top,Collins,Stir with ice and strain into a chilled Collins glass
+Beer and a Smoke,Cholula,4dashes,Build,Collins,Stir with ice and strain into a chilled Collins glass
+Beer and a Smoke,Sombra Mezcal,1oz,Build,Collins,Stir with ice and strain into a chilled Collins glass
+Beer and a Smoke,The Bitter Truth Celery Bitters,1dash,Build,Collins,Stir with ice and strain into a chilled Collins glass
+Beer and a Smoke,Lime Zest,1,Garnish,Collins,Stir with ice and strain into a chilled Collins glass
+Beer and a Smoke,Orange Zest,1,Garnish,Collins,Stir with ice and strain into a chilled Collins glass
+Beer and a Smoke,Lime Juice,.75oz,Build,Collins,Stir with ice and strain into a chilled Collins glass
+Beer and a Smoke,Celery Salt,,Rim,Collins,Stir with ice and strain into a chilled Collins glass
+Beer and a Smoke,Ground Black Pepper,,Rim,Collins,Stir with ice and strain into a chilled Collins glass
+Beer and a Smoke,Kosher Salt,,Rim,Collins,Stir with ice and strain into a chilled Collins glass
+Beer Cassis,Brooklyn Brewery Local 1,6oz,Top,Wine,Stir with ice and strain into a chilled white wine glass
+Beer Cassis,Dubonnet Rouge,1oz,Build,Wine,Stir with ice and strain into a chilled white wine glass
+Beer Cassis,Lemon Twist,1,Garnish,Wine,Stir with ice and strain into a chilled white wine glass
+Beer Cassis,Theurlet Creme de Cassis,.25oz,Build,Wine,Stir with ice and strain into a chilled white wine glass
+Bee's Knees,Plymouth Gin,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Bee's Knees,Honey Syrup,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Bee's Knees,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Bee's Sip,Chamomile-Infused Barsol Quebranta Pisco,2.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Bee's Sip,"Masumi ""Okuden"" Junmai Sake",1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Bee's Sip,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Bee's Sip,Barenjager Honey Liqueur,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Bee's Sip,St. Germain Elderflower Liqueur,,Rinse,Coupe,Stir with ice and strain into a chilled coupe
+Benton's Old-Fashioned,Benton's Bacon Fat-Infused Four Roses Bourbon,2oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Benton's Old-Fashioned,Angostura Bitters,2dashes,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Benton's Old-Fashioned,Orange Twist,1,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Benton's Old-Fashioned,Deep Mountain Grade B Maple Syrup,.25oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Berlioni,Tanqueray Gin,1.5oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Berlioni,Orange Twist,1,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Berlioni,Cynar,.75oz,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Berlioni,Noilly Prat Dry Vermouth,.5oz,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Betsy Ross,Pierre Ferrand Ambre Cognac,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Betsy Ross,Angostura Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Betsy Ross,Pinch Grated Nutmeg,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Betsy Ross,Dow's Ruby Port,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Betsy Ross,Grand Marnier,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Betula,Birch-Infused Rittenhouse Bonded Rye Whiskey,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Betula,Matusalem Gran Reserva Rum,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Betula,Star Anise Pod,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Betula,Deep Mountain Grade B Maple Syrup,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Betula,Lemon Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Bijou,Dolin Sweet Vermouth,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Bijou,Green Chartreuse,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Bijou,Tanqueray Gin,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Bijou,House Orange Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Bijou,Cherry,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Bijou,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Bizet,Moet Imperial Champagne,1oz,Top,Coupe,Stir with ice and strain into a chilled coupe
+Bizet,Shinn Estate Rose,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Bizet,Flamed Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Bizet,Amaro Ciociaro,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Bizet,Luxardo Bitter,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Black Flip,Brooklyn Black Chocolate Stout,2oz,Build,Fizz,"Swirl to decarbonate beer, dry-shake and then shake with ice and strain into a chilled fizz glass"
+Black Flip,Cruzan Black Strap Rum,1.5oz,Build,Fizz,"Swirl to decarbonate beer, dry-shake and then shake with ice and strain into a chilled fizz glass"
+Black Flip,Pinch Grated Nutmeg,1,Garnish,Fizz,"Swirl to decarbonate beer, dry-shake and then shake with ice and strain into a chilled fizz glass"
+Black Flip,Whole Egg,1,Build,Fizz,"Swirl to decarbonate beer, dry-shake and then shake with ice and strain into a chilled fizz glass"
+Black Flip,Demerara Syrup,.5oz,Build,Fizz,"Swirl to decarbonate beer, dry-shake and then shake with ice and strain into a chilled fizz glass"
+Black Jack,Cherry,3,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Black Jack,Pierre Ferrand Ambre Cognac,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Black Jack,9th Street Alphabet City Coffee Concentrate,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Black Jack,Clear Creek Kirschwasser,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Black Jack,Demerara Syrup,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Black Thorn (Irish),Black Bush Irish Whiskey,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Black Thorn (Irish),Angostura Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Black Thorn (Irish),Dolin Dry Vermouth,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Black Thorn (Irish),Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Black Thorn (Irish),St. George Absinthe,,Rinse,Coupe,Stir with ice and strain into a chilled coupe
+Blackbeard,Blackberry,4,Muddle,Rocks,Dry-shake and pour unstrained into a chilled rocks glass filled with pebble ice
+Blackbeard,Beefeater Gin,1.5oz,Build,Rocks,Dry-shake and pour unstrained into a chilled rocks glass filled with pebble ice
+Blackbeard,Mint Sprig,1,Garnish,Rocks,Dry-shake and pour unstrained into a chilled rocks glass filled with pebble ice
+Blackbeard,Krogstad Aquavit,.75oz,Build,Rocks,Dry-shake and pour unstrained into a chilled rocks glass filled with pebble ice
+Blackbeard,Pineapple Juice,.75oz,Build,Rocks,Dry-shake and pour unstrained into a chilled rocks glass filled with pebble ice
+Blackbeard,Agave Syrup,.5oz,Build,Rocks,Dry-shake and pour unstrained into a chilled rocks glass filled with pebble ice
+Blackbeard,Lemon Juice,.5oz,Build,Rocks,Dry-shake and pour unstrained into a chilled rocks glass filled with pebble ice
+Blackstar,Smirnoff Black Vodka,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Blackstar,Star Anise Pod,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Blackstar,Grapefruit Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Blackstar,Lime Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Blackstar,Borsci Sambuca,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Blackstar,Simple Syrup,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Blackthorn (English),House Orange Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Blackthorn (English),Plymouth Gin,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Blackthorn (English),Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Blackthorn (English),Carpano Antica Sweet Vermouth,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Blackthorn (English),Plymouth Sloe Gin,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Blackthorn Rose,Hendrick's Gin,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Blackthorn Rose,Mymoune Rose Syrup,1barspoon,Build,Coupe,Stir with ice and strain into a chilled coupe
+Blackthorn Rose,Lillet Rouge,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Blackthorn Rose,Plymouth Sloe Gin,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Blinker,Wild Turkey Rye Whiskey,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Blinker,Grapefruit Juice,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Blinker,Bonne Maman Raspberry Preserves,1barspoon,Build,Coupe,Shake with ice and strain into a chilled coupe
+Blinker,Simple Syrup,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Blood and Sand,Famous Grouse Blended Scotch Whisky,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Blood and Sand,Orange Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Blood and Sand,Carpano Antica Sweet Vermouth,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Blood and Sand,Cherry Heering,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Bobby Burns,Benromach 12-Year-Old Single Malt Scotch Whisky,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Bobby Burns,Benedictine,1barspoon,Build,Coupe,Stir with ice and strain into a chilled coupe
+Bobby Burns,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Bobby Burns,Martini Sweet Vermouth,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Brandy Crusta,Hine V.S.O.P. Cognac,2oz,Build,Wine,Shake with ice and strain into a chilled wine glass
+Brandy Crusta,Lemon Peel,1,Garnish,Wine,Shake with ice and strain into a chilled wine glass
+Brandy Crusta,Orange Peel,1,Garnish,Wine,Shake with ice and strain into a chilled wine glass
+Brandy Crusta,Lemon Juice,.75oz,Build,Wine,Shake with ice and strain into a chilled wine glass
+Brandy Crusta,Luxardo Maraschino Liqueur,.5oz,Build,Wine,Shake with ice and strain into a chilled wine glass
+Brandy Crusta,Marie Brizard Orange Curacao,.5oz,Build,Wine,Shake with ice and strain into a chilled wine glass
+Brandy Crusta,Sugar,,Rim,Wine,Shake with ice and strain into a chilled wine glass
+Brazilian Tea Punch,Sencha Green Tea-Infused Leblon Cachaca,2oz,Build,Rocks,"Add everything to a chilled rocks glass, then top with pebble ice. Swizzle, then top with more pebble ice and swizzle again"
+Brazilian Tea Punch,Lemongrass Syrup,1barspoon,Build,Rocks,"Add everything to a chilled rocks glass, then top with pebble ice. Swizzle, then top with more pebble ice and swizzle again"
+Brazilian Tea Punch,Lime Disc,1,Build,Rocks,"Add everything to a chilled rocks glass, then top with pebble ice. Swizzle, then top with more pebble ice and swizzle again"
+Brewer's Breakfast,Honey Nut Cheerios,8,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Brewer's Breakfast,Masumi Arabashiri Sake,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Brewer's Breakfast,Glen Thunder Corn Whiskey,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Brewer's Breakfast,Galliano L'Autentico,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Bronx,Beefeater Gin,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Bronx,Orange Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Bronx,Carpano Antica Sweet Vermouth,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Bronx,Dolin Dry Vermouth,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Brooklyn,Rittenhouse Bonded Rye Whiskey,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Brooklyn,Dolin Dry Vermouth,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Brooklyn,Amer Picon,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Brooklyn,Luxardo Maraschino Liqueur,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Brown Bomber,George Dickel No. 12 Tennessee Whisky,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Brown Bomber,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Brown Bomber,Lillet Blanc,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Brown Bomber,Suze,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Brown Derby,Maker's Mark Bourbon,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Brown Derby,Grapefruit Juice,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Brown Derby,Honey Syrup,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Bubbaloo,Peruvian Amargo Bitters,3dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Bubbaloo,Macchu Pisco,2.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Bubbaloo,Carpano Antica Sweet Vermouth,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Bubbaloo,Rothman & Winter Orchard Apricot,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Buona Notte,Walnut-Infused Hine V.S.O.P. Cognac,2oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Buona Notte,Orange Twist,1,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Buona Notte,Yellow Chartreuse,.5oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Buona Notte,Amaro Ciociaro,.25oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+CafÃ© Arroz,Horchata,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+CafÃ© Arroz,Gran Centenario Reposado Tequila,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+CafÃ© Arroz,Pinch Grated Cinnamon,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+CafÃ© Arroz,Kahlua,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Caipirinha,Beleza Pura Cachaca,2oz,Build,Rocks,Shake with ice and pour unstrained into a chilled rocks glass
+Caipirinha,Demerara Sugar,2barspoons,Build,Rocks,Shake with ice and pour unstrained into a chilled rocks glass
+Caipirinha,Lime Wedge,2,Muddle,Rocks,Shake with ice and pour unstrained into a chilled rocks glass
+Cameron's Kick,Famous Grouse Blended Scotch Whisky,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cameron's Kick,Jameson Irish Whiskey,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cameron's Kick,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cameron's Kick,Kassatly Chtaura Orgeat,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Caprice,House Orange Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Caprice,Beefeater Gin,1.5,Build,Coupe,Stir with ice and strain into a chilled coupe
+Caprice,Dolin Dry Vermouth,1.5,Build,Coupe,Stir with ice and strain into a chilled coupe
+Caprice,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Caprice,Benedictine,0.5,Build,Coupe,Stir with ice and strain into a chilled coupe
+Cavalier,Hine V.S.O.P. Cognac,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cavalier,House Orange Bitters,1dash,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cavalier,Bonne Maman Apricot Preserves,1barspoon,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cavalier,Lemon Peel,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Cavalier,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cavalier,Cointreau,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cavalier,Kassatly Chtaura Orgeat,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Champagne Cocktail,Moet Imperial Champagne,6.5oz,Build,Flute,Add champagne to chilled flute then drop in sugar cube soaked in bitters
+Champagne Cocktail,Angostura Bitters,2dashes,Build,Flute,Add champagne to chilled flute then drop in sugar cube soaked in bitters
+Champagne Cocktail,Lemon Twist,1,Garnish,Flute,Add champagne to chilled flute then drop in sugar cube soaked in bitters
+Champagne Cocktail,Sugar Cube,1,Build,Flute,Add champagne to chilled flute then drop in sugar cube soaked in bitters
+Champs-Elysees,Hine V.S.O.P. Cognac,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Champs-Elysees,Angostura Bitters,1dash,Build,Coupe,Shake with ice and strain into a chilled coupe
+Champs-Elysees,Lemon Twist,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Champs-Elysees,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Champs-Elysees,Green Chartreuse,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Champs-Elysees,Simple Syrup,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cherry Pop,Plymouth Gin,2oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Cherry Pop,Pitted Cherry,2,Muddle,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Cherry Pop,Lemon Juice,1oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Cherry Pop,Pitted Cherry,1,Garnish,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Cherry Pop,Luxardo Maraschino Liqueur,.5oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Cherry Pop,Simple Syrup,.5oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Chien Chaud,Liquiteria Coconut Water,2oz,Build,Fizz,Shake with ice and strain into a chilled fizz glass filled with ice
+Chien Chaud,Angostura Bitters,2dashes,Build,Fizz,Shake with ice and strain into a chilled fizz glass filled with ice
+Chien Chaud,J.M. Rhum Blanc,1.5oz,Build,Fizz,Shake with ice and strain into a chilled fizz glass filled with ice
+Chien Chaud,Lime Wheel,1,Garnish,Fizz,Shake with ice and strain into a chilled fizz glass filled with ice
+Chien Chaud,Yellow Chartreuse,.25oz,Build,Fizz,Shake with ice and strain into a chilled fizz glass filled with ice
+Chrysanthemum,Dolin Dry Vermouth,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Chrysanthemum,House Orange Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Chrysanthemum,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Chrysanthemum,Benedictine,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Chrysanthemum,Vieux Pontarlier Absinthe,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Cinema Highball,Coca-Cola Classic,4.5oz,Build,Collins,Build in a chilled Collins glass filled with ice cubes
+Cinema Highball,Popcorn-Infused Flor de Cana Silver Dry Rum,2oz,Build,Collins,Build in a chilled Collins glass filled with ice cubes
+Cloister,Tanqueray Gin,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cloister,Grapefruit Twist,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Cloister,Grapefruit Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cloister,Yellow Chartreuse,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cloister,Lemon Juice,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cloister,Simple Syrup,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Clover Club,Plymouth Gin,2oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Clover Club,Bonne Maman Raspberry Preserves,1barspoon,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Clover Club,Egg White,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Clover Club,Lemon Juice,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Clover Club,Simple Syrup,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Coconut Colada,Flor de Cana Silver Dry Rum,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Coconut Colada,Ciaco Bella Coconut Sorbet,1scoop,Build,Coupe,Shake with ice and strain into a chilled coupe
+Coconut Colada,Pineapple Juice,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Coconut Colada,Lime Wheel,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Coconut Colada,Lime Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Coda,Lime Juice,1oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Coda,Neisson Rhum Blanc,1oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Coda,Pampero Aniversario Rum,1oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Coda,Pinch Grated Nutmeg,1,Garnish,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Coda,Demerara Syrup,.5oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Coda,St. Elizabeth Allspice Dram,.5oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Coffee Cocktail,Martell V.S.O.P. Cognac,1.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Coffee Cocktail,Noval Black Port,1.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Coffee Cocktail,Pinch Grated Nutmeg,1,Garnish,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Coffee Cocktail,Whole Egg,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Coffee Cocktail,Simple Syrup,.25oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Condiment Cocktail,Partida Reposado Tequila,2oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Condiment Cocktail,The Bitter Truth Celery Bitters,2dashes,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Condiment Cocktail,Gulden's Spicy Brown Mustard,1/8 tsp,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Condiment Cocktail,Lime Twist,1,Garnish,Coupe,Shake with ice and fine-strain into a chilled coupe
+Condiment Cocktail,Benedictine,.75oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Condiment Cocktail,Lime Juice,.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Condiment Cocktail,Lustau Palo Cortado Sherry,.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Conquistador,House Orange Bitters,2dashes,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Conquistador,Matusalem Gran Reserva Rum,1oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Conquistador,Siembra Azul Blanco Tequila,1oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Conquistador,Egg White,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Conquistador,Simple Syrup,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Conquistador,Lemon Juice,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Conquistador,Lime Juice,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Corpse Reviver No. 2,Cointreau,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Corpse Reviver No. 2,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Corpse Reviver No. 2,Lillet Blanc,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Corpse Reviver No. 2,Plymouth Gin,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Corpse Reviver No. 2,Vieux Pontarlier Absinthe,,Rinse,Coupe,Shake with ice and strain into a chilled coupe
+Cosmopolitan,Hangar One Buddha's Hand Vodka,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cosmopolitan,Orange Twist,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Cosmopolitan,Cointreau,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cosmopolitan,Lime Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cosmopolitan,Lakewood Cranberry Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cosmopolitan,Simple Syrup,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Cranberry Cobbler,Macerated Cranberry,4,Muddle,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Cranberry Cobbler,Macerated Cranberry,3,Garnish,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Cranberry Cobbler,Beefeater Gin,2oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Cranberry Cobbler,Lemon Wedge,1,Muddle,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Cranberry Cobbler,Mint Sprig,1,Garnish,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Cranberry Cobbler,Orange Wheel,1,Muddle,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Cranberry Cobbler,Lustau East India Sherry,.75oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Cranberry Cobbler,Cranberry Syrup,.5oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Crimson Tide,Lemon Hart Overproof Rum,1.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Crimson Tide,Spiced Sorrel,1.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Crimson Tide,Candied Ginger,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Crimson Tide,Lime Wheel,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Crimson Tide,Club Soda,.75oz,Top,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Crimson Tide,Lime Juice,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Crimson Tide,Canton Ginger Liqueur,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Cuzco,Barsol Quebranta Pisco,2oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Cuzco,Grapefruit Twist,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Cuzco,Aperol,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Cuzco,Simple Syrup,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Cuzco,Grapefruit Juice,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Cuzco,Lemon Juice,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Cuzco,Clear Creek Kirschwasser,,Rinse,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Daiquiri,Banks 5 Island Rum,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Daiquiri,Lime Wheel,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Daiquiri,Lime Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Daiquiri,Simple Syrup,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+De La Louisiane,Peychaud's Bitters,3dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+De La Louisiane,St. George Absinthe,3dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+De La Louisiane,Brandied Cherry,3,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+De La Louisiane,Wild Turkey Rye Whiskey,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+De La Louisiane,Benedictine,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+De La Louisiane,Dolin Sweet Vermouth,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Death Bed,Pampero Aniversario Rum,1oz,Build,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Death Bed,Brandied Cherry,1,Garnish,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Death Bed,Lime Wheel,1,Garnish,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Death Bed,Barbancourt Rhum Blanc,.75oz,Build,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Death Bed,Cherry Heering,.75oz,Build,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Death Bed,Lime Juice,.75oz,Build,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Death Bed,Pineapple Juice,.5oz,Build,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Desert Rose,Rose-Infused Plymouth Gin,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Desert Rose,Pink Rose Petal,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Desert Rose,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Desert Rose,Perfect Purees of Napa Valley Prickly Pear Puree,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Desert Rose,Simple Syrup,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Deshler,Peychaud's Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Deshler,Dubonnet Rouge,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Deshler,Rittenhouse Bonded Rye Whiskey,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Deshler,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Deshler,Cointreau,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Dewey D.,Old Overholt Rye Whiskey,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Dewey D.,Angostura Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Dewey D.,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Dewey D.,Lustau East India Sherry,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Dewey D.,Aperol,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Diamondback,Rittenhouse Bonded Rye Whiskey,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Diamondback,Laird's Bonded Apple Brandy,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Diamondback,Yellow Chartreuse,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Donizetti,Tanqueray Gin,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Donizetti,Moet Imperial Champagne,1oz,Top,Coupe,Stir with ice and strain into a chilled coupe
+Donizetti,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Donizetti,Amaro Ciociaro,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Donizetti,Rothman & Winter Orchard Apricot,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Dry County Cocktail,George Dickel No. 12 Tennessee Whisky,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Dry County Cocktail,The Bitter Truth Lemon Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Dry County Cocktail,Dolin Dry Vermouth,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Dry County Cocktail,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Dry County Cocktail,Canton Ginger Liqueur,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Duboudreau Cocktail,Rittenhouse Bonded Rye Whiskey,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Duboudreau Cocktail,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Duboudreau Cocktail,Dubonnet Rouge,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Duboudreau Cocktail,Fernet Branca,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Duboudreau Cocktail,St. Germain Elderflower Liqueur,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Dulce de Leche,Don Julio Anejo Tequila,1.25oz,Build,Coupe,"Dry-shake, then shake with ice and strain into a chilled coupe"
+Dulce de Leche,Grapefruit Twist,1,Build,Coupe,"Dry-shake, then shake with ice and strain into a chilled coupe"
+Dulce de Leche,Pinch Grated Cinnamon,1,Garnish,Coupe,"Dry-shake, then shake with ice and strain into a chilled coupe"
+Dulce de Leche,Whole Egg,1,Build,Coupe,"Dry-shake, then shake with ice and strain into a chilled coupe"
+Dulce de Leche,Toro Albala Pedro Ximenez Sherry,.75oz,Build,Coupe,"Dry-shake, then shake with ice and strain into a chilled coupe"
+Dulce de Leche,Heavy Cream,.5oz,Build,Coupe,"Dry-shake, then shake with ice and strain into a chilled coupe"
+East India Cocktail,House Orange Bitters,2dashes,Build,Coupe,Shake with ice and strain into a chilled coupe
+East India Cocktail,Martell V.S.O.P. Cognac,1.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+East India Cocktail,Orange Twist,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+East India Cocktail,Marie Brizard Orange Curacao,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+East India Cocktail,Pineapple Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+East India Cocktail,Pampero Aniversario Rum,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+East Village Athletic Club Cocktail,Siembra Azul Blanco Tequila,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+East Village Athletic Club Cocktail,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+East Village Athletic Club Cocktail,Grand Marnier,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+East Village Athletic Club Cocktail,Yellow Chartreuse,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Eclipse Cocktail,El Tesoro Anejo Tequila,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Eclipse Cocktail,Lemon Twist,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Eclipse Cocktail,Aperol,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Eclipse Cocktail,Cherry Heering,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Eclipse Cocktail,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Eclipse Cocktail,Del Maguey Vida Mezcal,,Rinse,Coupe,Shake with ice and strain into a chilled coupe
+Edgewood,Grapefruit Juice,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Edgewood,Plymouth Gin,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Edgewood,Pinch Kosher Salt,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Edgewood,Lillet Blanc,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Edgewood,Punt e Mes,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+El Burro,House Ginger Beer,1oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+El Burro,Siembra Azul Reposado Tequila,1.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+El Burro,Candied Ginger,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+El Burro,Lime Wheel,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+El Burro,Lime Juice,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+El Burro,Pineapple Juice,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+El Burro,Simple Syrup,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+El Burro,Vieux Pontarlier Absinthe,.25oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+El Diablo,Siembra Azul Blanco Tequila,2oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+El Diablo,House Ginger Beer,1oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+El Diablo,Candied Ginger,1,Garnish,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+El Diablo,Lemon Wheel,1,Garnish,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+El Diablo,Lemon Juice,.75oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+El Diablo,Theurlet Creme de Cassis,.75oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+El Molino,Sombra Mezcal,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+El Molino,Lustau Palo Cortado Sherry,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+El Molino,Marie Brizard White Creme de Cacao,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+El Molino,St. Elizabeth Allspice Dram,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+El Puente,Jose Cuervo Platino Tequila,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+El Puente,Grapefruit Twist,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+El Puente,Grapefruit Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+El Puente,Martini Bianco Vermouth,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+El Puente,St. Germain Elderflower Liqueur,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+El Puente,Del Maguey Vida Mezcal,,Rinse,Coupe,Shake with ice and strain into a chilled coupe
+Ephemeral,Ransom Old Tom Gin,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Ephemeral,Dolin Blanc Vermouth,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Ephemeral,The Bitter Truth Celery Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Ephemeral,St. Germain Elderflower Liqueur,1barspoon,Build,Coupe,Stir with ice and strain into a chilled coupe
+Ephemeral,Grapefruit Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Espresso Bongo,Appleton Estate Reserve Rum,2oz,Build,Tiki Mug,Shake with ice and pour unstrained into a chilled tiki mug
+Espresso Bongo,Boiron Passion Fruit Puree,.5oz,Build,Tiki Mug,Shake with ice and pour unstrained into a chilled tiki mug
+Espresso Bongo,Illy Espresso Liqueur,.5oz,Build,Tiki Mug,Shake with ice and pour unstrained into a chilled tiki mug
+Espresso Bongo,Lime Juice,.5oz,Build,Tiki Mug,Shake with ice and pour unstrained into a chilled tiki mug
+Espresso Bongo,Orange Juice,.5oz,Build,Tiki Mug,Shake with ice and pour unstrained into a chilled tiki mug
+Espresso Bongo,Pineapple Juice,.5oz,Build,Tiki Mug,Shake with ice and pour unstrained into a chilled tiki mug
+Espresso Bongo,Simple Syrup,.5oz,Build,Tiki Mug,Shake with ice and pour unstrained into a chilled tiki mug
+Falling Leaves,Peychaud's Bitters,3dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Falling Leaves,Dr. Konstantin Frank Dry Riesling,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Falling Leaves,Clear Creek Pear Brandy,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Falling Leaves,Star Anise Pod,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Falling Leaves,Marie Brizard Orange Curacao,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Falling Leaves,Honey Syrup,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Field Cocktail,Pierre Ferrand Ambre Cognac,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Field Cocktail,Noilly Prat Dry Vermouth,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Field Cocktail,Pineapple Leaf,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Field Cocktail,Pineapple Juice,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Figetaboutit,Brandied Cherry,3,Garnish,Coupe,Shake with ice and fine-strain into a chilled coupe
+Figetaboutit,Bulleit Bourbon,2oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Figetaboutit,Angostura Bitters,2dashes,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Figetaboutit,St. Dalfour Fig Jam,1barspoon,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Figetaboutit,Orange Twist,1,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Figetaboutit,Lemon Juice,.75oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Figetaboutit,Luxardo Amaretto,.25oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Fish House Punch,Gosling's Black Seal Rum,1.5oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Fish House Punch,Pinch Grated Nutmeg,1,Garnish,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Fish House Punch,Lemon Juice,.5oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Fish House Punch,Mathilde Peche,.5oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Fish House Punch,Pierre Ferrand Ambre Cognac,.5oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Fish House Punch,Simple Syrup,.5oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Fish House Punch,Lime Juice,.25oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Flora Astoria,Lavender Tincture,4dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Flora Astoria,Hendrick's Gin,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Flora Astoria,John D. Taylor's Velvet Falernum,1barspoon,Build,Coupe,Stir with ice and strain into a chilled coupe
+Flora Astoria,Dried Lavender Sprig,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Flora Astoria,Dolin Blanc Vermouth,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Flora Astoria,Dolin Dry Vermouth,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Flying Dutchman,Luxardo Maraschino Liqueur,1barspoon,Build,Coupe,Shake with ice and strain into a chilled coupe
+Flying Dutchman,Brandied Cherry,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Flying Dutchman,Bols Genever,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Flying Dutchman,Clear Creek Plum Brandy,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Flying Dutchman,Creme Yvette,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Flying Dutchman,Lemon Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Flying Dutchman,Pineapple Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Fog Cutter,Bacardi 8 Rum,1oz,Build,Tiki Mug,Shake with ice and pour unstrained into a chilled tiki mug
+Fog Cutter,Hine V.S.O.P. Cognac,1oz,Build,Tiki Mug,Shake with ice and pour unstrained into a chilled tiki mug
+Fog Cutter,Lemon Juice,1.5oz,Build,Tiki Mug,Shake with ice and pour unstrained into a chilled tiki mug
+Fog Cutter,Mint Sprig,1,Garnish,Tiki Mug,Shake with ice and pour unstrained into a chilled tiki mug
+Fog Cutter,Orange Juice,.75oz,Build,Tiki Mug,Shake with ice and pour unstrained into a chilled tiki mug
+Fog Cutter,Kassatly Chtaura Orgeat,.5oz,Build,Tiki Mug,Shake with ice and pour unstrained into a chilled tiki mug
+Fog Cutter,Lustau Cream Sherry,.5oz,Float,Tiki Mug,Shake with ice and pour unstrained into a chilled tiki mug
+Fog Cutter,Tanqueray Gin,.5oz,Build,Tiki Mug,Shake with ice and pour unstrained into a chilled tiki mug
+Foreign Legion,Fee Brothers Rhubarb Bitters,1dash,Build,Rocks,Shake with ice and strain over an ice sphere into a chilled rocks glass
+Foreign Legion,Marie Brizard Dark Creme de Cacao,1barspoon,Build,Rocks,Shake with ice and strain over an ice sphere into a chilled rocks glass
+Foreign Legion,Mount Gay X.O. Rum,1.5oz,Build,Rocks,Shake with ice and strain over an ice sphere into a chilled rocks glass
+Foreign Legion,Orange Twist,1,Garnish,Rocks,Shake with ice and strain over an ice sphere into a chilled rocks glass
+Foreign Legion,Aperol,.5oz,Build,Rocks,Shake with ice and strain over an ice sphere into a chilled rocks glass
+Foreign Legion,Dubonnet Rouge,.5oz,Build,Rocks,Shake with ice and strain over an ice sphere into a chilled rocks glass
+Foreign Legion,Lustau Manzanilla Sherry,.5oz,Build,Rocks,Shake with ice and strain over an ice sphere into a chilled rocks glass
+Framboise Fizz,Raspberry,3,Garnish,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+Framboise Fizz,Oud Beersel Framboise,2oz,Top,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+Framboise Fizz,Siete Leguas Reposado Tequila,1.5oz,Build,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+Framboise Fizz,Lemon Juice,.75oz,Build,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+Framboise Fizz,Marie Brizard Dark Creme de Cacao,.75oz,Build,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+Frankfort Rose,Hibiscus-Infused Bernheim Wheat Whiskey,2oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Frankfort Rose,Egg White,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Frankfort Rose,Lemon Twist,1,Garnish,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Frankfort Rose,Lemon Juice,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Frankfort Rose,Simple Syrup,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+French 75,Moet Imperial Champagne,1oz,Top,Coupe,Shake with ice and strain into a chilled coupe
+French 75,Tanqueray Gin,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+French 75,Lemon Twist,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+French 75,Lemon Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+French 75,Simple Syrup,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+French Maid,Mint Leaf,6-8,Muddle,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+French Maid,Cucumber Wheel,3,Muddle,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+French Maid,House Ginger Beer,1oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+French Maid,Hine V.S.O.P. Cognac,1.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+French Maid,Cucumber Wheel,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+French Maid,Mint Sprig,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+French Maid,Lime Juice,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+French Maid,Simple Syrup,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+French Maid,John D. Taylor's Velvet Falernum,.25oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Fresa Verde,Gran Centenario Blanco Tequila,2oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Fresa Verde,Green Pepper Slice,2,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Fresa Verde,Strawberry,2,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Fresa Verde,Strawberry Slice,1,Garnish,Coupe,Shake with ice and fine-strain into a chilled coupe
+Fresa Verde,Lime Juice,.75oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Fresa Verde,Al Wadi Pomegranate Molasses,.25oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Frisco,Old Potrero Hotaling's Rye Whiskey,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Frisco,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Frisco,Benedictine,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Gilchrist,Fee Brothers Grapefruit Bitters,2dashes,Build,Coupe,Shake with ice and strain into a chilled coupe
+Gilchrist,Compass Box Asyla Blended Scotch Whisky,1.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Gilchrist,Lemon Twist,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Gilchrist,Clear Creek Pear Brandy,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Gilchrist,Grapefruit Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Gilchrist,Averna Amaro,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Gimlet,Plymouth Gin,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Gimlet,Lime Wheel,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Gimlet,Lime Cordial,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Gimlet,Lime Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Gin & Tonic,Club Soda,3.5oz,Build,Collins,Add everything to a chilled Collins glass filled with ice and stir briefly
+Gin & Tonic,Tanqueray Gin,2oz,Build,Collins,Add everything to a chilled Collins glass filled with ice and stir briefly
+Gin & Tonic,Lime Wedge,1,Garnish,Collins,Add everything to a chilled Collins glass filled with ice and stir briefly
+Gin & Tonic,Tonic Syrup,.75oz,Build,Collins,Add everything to a chilled Collins glass filled with ice and stir briefly
+Girl from Jerez,Mae de Ouro Cachaca,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Girl from Jerez,Rhum Clement V.S.O.P.,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Girl from Jerez,St. Elizabeth Allspice Dram,1barspoon,Build,Coupe,Shake with ice and strain into a chilled coupe
+Girl from Jerez,Pinch Grated Nutmeg,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Girl from Jerez,Lime Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Girl from Jerez,Lustau Pedro Ximenez Sherry,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Gold Coast,Karlsson's Gold Vodka,2oz,Build,Rocks,Stir with ice and fine-strain over one large cube into a chilled rocks glass
+Gold Coast,Diluted Aftel Black Pepper Essence,2,Spritz,Rocks,Stir with ice and fine-strain over one large cube into a chilled rocks glass
+Gold Coast,Dill Sprig,1,Muddle,Rocks,Stir with ice and fine-strain over one large cube into a chilled rocks glass
+Gold Coast,Carlshamns Flaggpunch,.5oz,Build,Rocks,Stir with ice and fine-strain over one large cube into a chilled rocks glass
+Gold Rush,Elijah Craig 12-Year-Old Bourbon,2oz,Build,Rocks,Shake with ice and strain over one large cube into a chilled rocks glass
+Gold Rush,Honey Syrup,1oz,Build,Rocks,Shake with ice and strain over one large cube into a chilled rocks glass
+Gold Rush,Lemon Juice,.75oz,Build,Rocks,Shake with ice and strain over one large cube into a chilled rocks glass
+Golden Star Fizz,Golden Star Sparkling White Jasmine Tea,3oz,Build,Fizz,Shake with ice and fine-strain into a chilled fizz glass
+Golden Star Fizz,Cucumber Slice,3,Muddle,Fizz,Shake with ice and fine-strain into a chilled fizz glass
+Golden Star Fizz,Krogstad Aquavit,2oz,Build,Fizz,Shake with ice and fine-strain into a chilled fizz glass
+Golden Star Fizz,Cucumber Slice,1,Garnish,Fizz,Shake with ice and fine-strain into a chilled fizz glass
+Golden Star Fizz,Dill Sprig,1,Muddle,Fizz,Shake with ice and fine-strain into a chilled fizz glass
+Golden Star Fizz,Lemon Juice,.75oz,Build,Fizz,Shake with ice and fine-strain into a chilled fizz glass
+Golden Star Fizz,Pineapple Juice,.75oz,Build,Fizz,Shake with ice and fine-strain into a chilled fizz glass
+Golden Star Fizz,St. George Absinthe,,Rinse,Fizz,Shake with ice and fine-strain into a chilled fizz glass
+Great Pumpkin,Southampton Pumpkin Ale,2oz,Build,Fizz,"Swirl to decarbonate beer, dry-shake and then shake with ice and strain into a chilled fizz glass"
+Great Pumpkin,Laird's Bonded Apple Brandy,1oz,Build,Fizz,"Swirl to decarbonate beer, dry-shake and then shake with ice and strain into a chilled fizz glass"
+Great Pumpkin,Rittenhouse Bonded Rye Whiskey,1oz,Build,Fizz,"Swirl to decarbonate beer, dry-shake and then shake with ice and strain into a chilled fizz glass"
+Great Pumpkin,Pinch Grated Nutmeg,1,Garnish,Fizz,"Swirl to decarbonate beer, dry-shake and then shake with ice and strain into a chilled fizz glass"
+Great Pumpkin,Whole Egg,1,Build,Fizz,"Swirl to decarbonate beer, dry-shake and then shake with ice and strain into a chilled fizz glass"
+Great Pumpkin,Deep Mountain Grade B Maple Syrup,.5oz,Build,Fizz,"Swirl to decarbonate beer, dry-shake and then shake with ice and strain into a chilled fizz glass"
+Green Deacon,Grapefruit Juice,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Green Deacon,Plymouth Gin,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Green Deacon,Plymouth Sloe Gin,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Green Deacon,St. George Absinthe,,Rinse,Coupe,Shake with ice and strain into a chilled coupe
+Green Harvest,Concord Grape,4,Muddle,Fizz,Stir with ice and fine-strain into a chilled fizz glass filled with ice
+Green Harvest,Concord Grape,3,Garnish,Fizz,Stir with ice and fine-strain into a chilled fizz glass filled with ice
+Green Harvest,Chilled Brewed Hibiscus Tea,2oz,Build,Fizz,Stir with ice and fine-strain into a chilled fizz glass filled with ice
+Green Harvest,Jose Cuervo Platino Tequila,1.5oz,Build,Fizz,Stir with ice and fine-strain into a chilled fizz glass filled with ice
+Green Harvest,Green Chartreuse,.5oz,Build,Fizz,Stir with ice and fine-strain into a chilled fizz glass filled with ice
+Greenpoint,Rittenhouse Bonded Rye Whiskey,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Greenpoint,Punt e Mes,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Greenpoint,Angostura Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Greenpoint,Yellow Chartreuse,1barspoon,Build,Coupe,Stir with ice and strain into a chilled coupe
+Hanky Panky,Beefeater Gin,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Hanky Panky,Carpano Antica Sweet Vermouth,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Hanky Panky,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Hanky Panky,Fernet Branca,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Harvest Moon,Abbott's Bitters,3dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Harvest Moon,Lillet Blanc,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Harvest Moon,Wild Turkey Rye Whiskey,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Harvest Moon,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Harvest Moon,Laird's Bonded Apple Brandy,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Harvest Moon,Green Chartreuse,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Harvest Sling,Laird's Bonded Apple Brandy,1.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Harvest Sling,Orange-Cherry Flag,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Harvest Sling,Benedictine,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Harvest Sling,Cherry Heering,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Harvest Sling,House Ginger Beer,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Harvest Sling,Lemon Juice,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Harvest Sling,Martini Sweet Vermouth,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Heirloom,Concord Grape,7,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Heirloom,Afel Anise Hyssop Essence,2,Spritz,Coupe,Shake with ice and fine-strain into a chilled coupe
+Heirloom,Hayman's Old Tom Gin,1.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Heirloom,Cynar,.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Heirloom,Lime Juice,.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Heirloom,Strega,.25oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Hemingway Daiquiri,Banks 5 Island Rum,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Hemingway Daiquiri,Lime Wheel,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Hemingway Daiquiri,Lime Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Hemingway Daiquiri,Grapefruit Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Hemingway Daiquiri,Luxardo Maraschino Liqueur,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Henry Hudson,Channing Daughters Scuttlehole Chardonnay,1oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Henry Hudson,Bols Genever,1.5oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Henry Hudson,Pinch Grated Nutmeg,1,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Henry Hudson,Lemon Juice,.5oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Henry Hudson,Simple Syrup,.5oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Henry Hudson,van Oosten Batavia Arrack,.25oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Honeymoon Cocktail,Laird's Bonded Apple Brandy,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Honeymoon Cocktail,Benedictine,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Honeymoon Cocktail,Lemon Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Honeymoon Cocktail,Marie Brizard Orange Curacao,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Hot Buttered Pisco,Hot Water,6oz,Build,Mug,Add everything to a pre-warmed heatproof mug and stir until vanilla butter dissolves
+Hot Buttered Pisco,Spiced Macchu Pisco,2oz,Build,Mug,Add everything to a pre-warmed heatproof mug and stir until vanilla butter dissolves
+Hot Buttered Pisco,Vanilla Butter,1barspoon,Build,Mug,Add everything to a pre-warmed heatproof mug and stir until vanilla butter dissolves
+Hot Buttered Pisco,Pinch Grated Nutmeg,1,Garnish,Mug,Add everything to a pre-warmed heatproof mug and stir until vanilla butter dissolves
+Hot Buttered Pisco,Sweetened Whipped Cream,,Top,Mug,Add everything to a pre-warmed heatproof mug and stir until vanilla butter dissolves
+Hotel D'Alsace,Bushmills Irish Whiskey,2oz,Build,Rocks,Stir with ice and fine-strain over one large cube into a chilled rocks glass
+Hotel D'Alsace,Rosemary Sprig,1,Garnish,Rocks,Stir with ice and fine-strain over one large cube into a chilled rocks glass
+Hotel D'Alsace,Rosemary Sprig,1,Muddle,Rocks,Stir with ice and fine-strain over one large cube into a chilled rocks glass
+Hotel D'Alsace,Benedictine,.5oz,Build,Rocks,Stir with ice and fine-strain over one large cube into a chilled rocks glass
+Hotel D'Alsace,Cointreau,.5oz,Build,Rocks,Stir with ice and fine-strain over one large cube into a chilled rocks glass
+Hotel Nacional Special,Bacardi 8 Rum,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Hotel Nacional Special,Pineapple Juice,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Hotel Nacional Special,Lime Wheel,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Hotel Nacional Special,Lime Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Hotel Nacional Special,Simple Syrup,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Hotel Nacional Special,Rothman & Winter Orchard Apricot,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Imperial Blueberry Fizz,Blueberry,2tbsp,Muddle,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+Imperial Blueberry Fizz,Moet Imperial Champagne,2.5oz,Top,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+Imperial Blueberry Fizz,Hine V.S.O.P. Cognac,1.5oz,Build,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+Imperial Blueberry Fizz,Edible Orchid,1,Garnish,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+Imperial Blueberry Fizz,Creme Yvette,.5oz,Build,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+Imperial Silver Corn Fizz,Corn Water,1oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Imperial Silver Corn Fizz,Moet Imperial Champagne,1oz,Top,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Imperial Silver Corn Fizz,George Dickel No. 12 Tennessee Whisky,1.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Imperial Silver Corn Fizz,Egg White,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Imperial Silver Corn Fizz,Honey Syrup,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Improved Whiskey Cocktail,Rittenhouse Bonded Rye Whiskey,2oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Improved Whiskey Cocktail,Angostura Bitters,2dashes,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Improved Whiskey Cocktail,Lemon Twist,1,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Improved Whiskey Cocktail,Luxardo Maraschino Liqueur,.25oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Improved Whiskey Cocktail,Simple Syrup,.25oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Improved Whiskey Cocktail,Vieux Pontarlier Absinthe,,Rinse,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Jack Rose,Laird's Bonded Apple Brandy,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Jack Rose,House Grenadine,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Jack Rose,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Japanese Cocktail,Hine V.S.O.P. Cognac,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Japanese Cocktail,Angostura Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Japanese Cocktail,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Japanese Cocktail,Kassatly Chtaura Orgeat,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Japanese Courage,"Kamoizumi ""Shusen"" Sake",6oz,Build,Mug,"Heat the sake in a bain-marie, pour everything into a pre-heated heatproof mug"
+Japanese Courage,Clove,6,Garnish,Mug,"Heat the sake in a bain-marie, pour everything into a pre-heated heatproof mug"
+Japanese Courage,Bols Genever,1oz,Build,Mug,"Heat the sake in a bain-marie, pour everything into a pre-heated heatproof mug"
+Japanese Courage,Lemon Wheel,1,Garnish,Mug,"Heat the sake in a bain-marie, pour everything into a pre-heated heatproof mug"
+Japanese Courage,Yellow Chartreuse,.5oz,Build,Mug,"Heat the sake in a bain-marie, pour everything into a pre-heated heatproof mug"
+Japanese Courage,Canton Ginger Liqueur,.25oz,Build,Mug,"Heat the sake in a bain-marie, pour everything into a pre-heated heatproof mug"
+Japanese Courage,Honey Syrup,.25oz,Build,Mug,"Heat the sake in a bain-marie, pour everything into a pre-heated heatproof mug"
+Jimmie Roosevelt,Moet Imperial Champagne,2oz,Top,Egg Coupe,"Stir the cognac with ice, strain into chilled egg coupe filled with three cracked ice cubes; add sugar cube and top then float."
+Jimmie Roosevelt,Remy Martin V.S.O.P. Cognac,1oz,Build,Egg Coupe,"Stir the cognac with ice, strain into chilled egg coupe filled with three cracked ice cubes; add sugar cube and top then float."
+Jimmie Roosevelt,Green Chartreuse,1barspoon,Float,Egg Coupe,"Stir the cognac with ice, strain into chilled egg coupe filled with three cracked ice cubes; add sugar cube and top then float."
+Jimmie Roosevelt,Demerara Sugar cube soaked in Angostura Bitters,1,Build,Egg Coupe,"Stir the cognac with ice, strain into chilled egg coupe filled with three cracked ice cubes; add sugar cube and top then float."
+Johnny Apple Collins,Fever-Tree Bitter Lemon Soda,2oz,Top,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Johnny Apple Collins,The Bitter Truth Jerry Thomas Bitters,2dashes,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Johnny Apple Collins,Maker's Mark Bourbon,1.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Johnny Apple Collins,Lemon Twist,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Johnny Apple Collins,Lemon Juice,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Johnny Apple Collins,Schonauer Apfel Schnapps,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Judgment Day,St. Elizabeth Allspice Dram,2,Spritz,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Judgment Day,Macchu Pisco,1.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Judgment Day,Egg White,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Judgment Day,Lemon Juice,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Judgment Day,Lime Juice,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Judgment Day,Simple Syrup,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Judgment Day,St. Germain Elderflower Liqueur,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Judgment Day,Pernod,,Rinse,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Junior,Rittenhouse Bonded Rye Whiskey,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Junior,Angostura Bitters,2dashes,Build,Coupe,Shake with ice and strain into a chilled coupe
+Junior,Lime Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Junior,Benedictine,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Kansai Kick,Yamazaki 12-Year-Old Japanese Single Malt Whisky,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Kansai Kick,Blandy's Sercial Madeira,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Kansai Kick,Lime Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Kansai Kick,Kassatly Chtaura Orgeat,.4oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Kin Kan,Kumquat Syrup,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Kin Kan,Beefeater Gin,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Kin Kan,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Kin Kan,St. Germain Elderflower Liqueur,,Rinse,Coupe,Shake with ice and strain into a chilled coupe
+Kina Miele,Dolin Dry Vermouth,1oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Kina Miele,The Bitter Truth Lemon Bitters,1dash,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Kina Miele,Grapefruit Twist,1,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Kina Miele,Cocchi Americano,.75oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Kina Miele,Nonino Gioiello,.5oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Kina Miele,Clear Creek Pear Brandy,.25oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+King Bee,Barsol Quebranta Pisco,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+King Bee,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+King Bee,Barenjager Honey Liqueur,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+King Bee,Benedictine,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+King Bee,Lustau Palo Cortado Sherry,.5oz,Float,Coupe,Shake with ice and strain into a chilled coupe
+Koyo,"Masumi ""Okuden"" Junmai Sake",2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Koyo,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Koyo,Dubonnet Rouge,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Koyo,Cynar,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Koyo,Yellow Chartreuse,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Koyo,St. Germain Elderflower Liqueur,,Rinse,Coupe,Stir with ice and strain into a chilled coupe
+L.E.S. Globetrotter,Wild Turkey Rye Whiskey,1.25oz,Build,Rocks,Stir with ice and strain over an ice sphere into a chilled rocks glass
+L.E.S. Globetrotter,Orange Twist,1,Garnish,Rocks,Stir with ice and strain over an ice sphere into a chilled rocks glass
+L.E.S. Globetrotter,Benedictine,.75oz,Build,Rocks,Stir with ice and strain over an ice sphere into a chilled rocks glass
+L.E.S. Globetrotter,Hine V.S.O.P. Cognac,.75oz,Build,Rocks,Stir with ice and strain over an ice sphere into a chilled rocks glass
+L.E.S. Globetrotter,Rhum Clement Creole Shrubb,.5oz,Build,Rocks,Stir with ice and strain over an ice sphere into a chilled rocks glass
+La Florida Cocktail,Banks 5 Island Rum,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+La Florida Cocktail,House Grenadine,1barspoon,Build,Coupe,Shake with ice and strain into a chilled coupe
+La Florida Cocktail,Lime Wheel,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+La Florida Cocktail,Lime Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+La Florida Cocktail,Marie Brizard White Creme de Cacao,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+La Florida Cocktail,Martini Sweet Vermouth,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+La Louche,Lillet Rouge,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+La Louche,Hendrick's Gin,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+La Louche,Lime Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+La Louche,Simple Syrup,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+La Louche,Yellow Chartreuse,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+La Perla,Lustau Manzanilla Sherry,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+La Perla,Partida Reposado Tequila,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+La Perla,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+La Perla,Mathilde Pear Liqueur,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Lacrimosa,Rittenhouse Bonded Rye Whiskey,2oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Lacrimosa,Flamed Orange Twist,1,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Lacrimosa,Amaro Ciociaro,.75oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Lacrimosa,Luxardo Bitter,.75oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Lake George,Glenlivet 12-Year-Old Single Malt Scotch Whisky,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Lake George,Jameson Irish Whiskey,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Lake George,Drambuie,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Lake George,Lemon Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Last Word,Green Chartreuse,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Last Word,Lime Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Last Word,Luxardo Maraschino Liqueur,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Last Word,Tanqueray Gin,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Lawn Dart,Partida Blanco Tequila,1oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Lawn Dart,Tanqueray Gin,1oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Lawn Dart,Green Pepper Slice,1,Muddle,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Lawn Dart,Lime Wheel,1,Garnish,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Lawn Dart,Umbrella,1,Garnish,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Lawn Dart,Agave Syrup,.75oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Lawn Dart,Lime Juice,.75oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Lawn Dart,Green Chartreuse,.25oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Le Pere Bis,Freshly Brewed Chamomile Tea,4oz,Build,Mug,Add everything to a pre-heated heatproof mug and stir
+Le Pere Bis,Clove,3,Garnish,Mug,Add everything to a pre-heated heatproof mug and stir
+Le Pere Bis,Ardbeg 10-Year-Old Single Malt Scotch Whisky,1.5oz,Build,Mug,Add everything to a pre-heated heatproof mug and stir
+Le Pere Bis,Lemon Wedge,1,Garnish,Mug,Add everything to a pre-heated heatproof mug and stir
+Le Pere Bis,Honey Syrup,.5oz,Build,Mug,Add everything to a pre-heated heatproof mug and stir
+Le Pere Bis,St. Germain Elderflower Liqueur,.5oz,Build,Mug,Add everything to a pre-heated heatproof mug and stir
+Leapfrog,Mint Leaf,6,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Leapfrog,House Orange Bitters,2dashes,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Leapfrog,Plymouth Gin,1oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Leapfrog,Lemon Juice,.75oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Leapfrog,Rothman & Winter Orchard Apricot,.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Leapfrog,Simple Syrup,.25oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Left Coast,Rothman & Winter Creme de Violette,1barspoon,Build,Coupe,Shake with ice and strain into a chilled coupe
+Left Coast,Anchor Genevieve,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Left Coast,Clear Creek Pear Brandy,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Left Coast,Lemon Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Left Coast,Luxardo Maraschino Liqueur,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Left Coast,Pineapple Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Left Hand Cocktail,Brandied Cherry,3,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Left Hand Cocktail,Bittermens Xocolatl Mole Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Left Hand Cocktail,Elijah Craig 12-Year-Old Bourbon,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Left Hand Cocktail,Campari,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Left Hand Cocktail,Carpano Antica Sweet Vermouth,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Lion's Tooth,Dandelion Root-Infused Rittenhouse Bonded Rye Whiskey,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Lion's Tooth,Lustau Palo Cortado Sherry,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Lion's Tooth,Yellow Chartreuse,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Lion's Tooth,St. Germain Elderflower Liqueur,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Little Bit Country,Bulleit Bourbon,2oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Little Bit Country,Angostura Bitters,1dash,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Little Bit Country,House Orange Bitters,1dash,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Little Bit Country,Flamed Orange Twist,1,Garnish,Coupe,Shake with ice and fine-strain into a chilled coupe
+Little Bit Country,Jalapeno Slice with few seeds,1,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Little Bit Country,Lemon Juice,.75oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Little Bit Country,Deep Mountain Grade B Maple Syrup,.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Little Bit Country,Luxardo Maraschino Liqueur,.25oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Luau,Large Straw,2,Garnish,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Luau,Angostura Bitters,1dash,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Luau,Lime Wheel,1,Garnish,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Luau,Orange Wheel,1,Garnish,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Luau,Umbrella,1,Garnish,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Luau,Appleton Estate V/X Rum,.75oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Luau,El Dorado 15-Year-Old Rum,.75oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Luau,Wray & Nephew Overproof Rum,.75oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Luau,Lime Juice,.5oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Luau,Simple Syrup,.5oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Luau,Boiron Passion Fruit Puree,.25oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Luau,Kassatly Chtaura Orgeat,.25oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Mae West Royal Diamond Fizz,Whiskey-soaked Goji Berry,3,Garnish,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Mae West Royal Diamond Fizz,Goji Berry-Infused Four Roses Single Barrel Bourbon,2oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Mae West Royal Diamond Fizz,Grapefruit Juice,1oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Mae West Royal Diamond Fizz,Whole Egg,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Mae West Royal Diamond Fizz,Pama Pomegranate Liqueur,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Mae West Royal Diamond Fizz,Cayenne,,Rim,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Mae West Royal Diamond Fizz,Cocoa Powder,,Rim,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Mae West Royal Diamond Fizz,Sugar,,Rim,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Mai-Tai,Banks 5 Island Rum,1oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Mai-Tai,Lime Juice,1oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Mai-Tai,Rhum Clement V.S.O.P.,1oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Mai-Tai,Mint Sprig,1,Garnish,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Mai-Tai,Kassatly Chtaura Orgeat,.5oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Mai-Tai,Marie Brizard Orange Curacao,.5oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with pebble ice
+Manhattan,Brandied Cherry,3,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Manhattan,Wild Turkey Rye Whiskey,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Manhattan,Angostura Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Manhattan,Martini Sweet Vermouth,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Margarita,El Tesoro Platinum Tequila,2oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice or a chilled coupe
+Margarita,Lime Wheel,1,Garnish,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice or a chilled coupe
+Margarita,Cointreau,.75oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice or a chilled coupe
+Margarita,Lime Juice,.75oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice or a chilled coupe
+Margarita,Agave Syrup,.25oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice or a chilled coupe
+Mariner,Compass Box Oak Cross Blended Malt Scotch Whisky,2oz,Build,Rocks,Shake with ice and strain over one large cube into a chilled rocks glass
+Mariner,Lemon Twist,1,Garnish,Rocks,Shake with ice and strain over one large cube into a chilled rocks glass
+Mariner,Black Cardamom Syrup,.5oz,Build,Rocks,Shake with ice and strain over one large cube into a chilled rocks glass
+Mariner,Lemon Juice,.25oz,Build,Rocks,Shake with ice and strain over one large cube into a chilled rocks glass
+Mariner,Pineapple Juice,.25oz,Build,Rocks,Shake with ice and strain over one large cube into a chilled rocks glass
+Martinez,Adam Elmegirab's Boker's Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Martinez,Dolin Sweet Vermouth,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Martinez,Hayman's Old Tom Gin,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Martinez,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Martinez,Luxardo Maraschino Liqueur,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Martini,Plymouth Gin,3oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Martini,Dolin Dry Vermouth,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Martini,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Mary Pickford,Banks 5 Island Rum,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Mary Pickford,Pineapple Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Mary Pickford,Luxardo Maraschino Liqueur,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Mary Pickford,House Grenadine,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Masataka Swizzle,Peychaud's Bitters,3dashes,Garnish,Rocks,"Add everything to a chilled rocks glass, then top with pebble ice. Swizzle, then top with more pebble ice and swizzle again"
+Masataka Swizzle,Demerara Syrup,1barspoon,Build,Rocks,"Add everything to a chilled rocks glass, then top with pebble ice. Swizzle, then top with more pebble ice and swizzle again"
+Masataka Swizzle,Nikka Taketsuru 12-Year-Old Japanese Malt Whisky,1.5oz,Build,Rocks,"Add everything to a chilled rocks glass, then top with pebble ice. Swizzle, then top with more pebble ice and swizzle again"
+Masataka Swizzle,Mint Sprig,1,Garnish,Rocks,"Add everything to a chilled rocks glass, then top with pebble ice. Swizzle, then top with more pebble ice and swizzle again"
+Masataka Swizzle,Lemon Juice,.5oz,Build,Rocks,"Add everything to a chilled rocks glass, then top with pebble ice. Swizzle, then top with more pebble ice and swizzle again"
+Masataka Swizzle,Luxardo Amaretto,.5oz,Build,Rocks,"Add everything to a chilled rocks glass, then top with pebble ice. Swizzle, then top with more pebble ice and swizzle again"
+Master Cleanse,Laird's Bonded Apple Brandy,2oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Master Cleanse,Herb Pharm Goldenseal Tincture,20drops,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Master Cleanse,Jalapeno Slice no seeds,2,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Master Cleanse,Jalapeno Slice no seeds,1,Garnish,Coupe,Shake with ice and fine-strain into a chilled coupe
+Master Cleanse,Lemon Juice,.75oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Master Cleanse,Deep Mountain Grade B Maple Syrup,.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+May Daisy,Hine V.S.O.P. Cognac,2oz,Build,Wine,Shake with ice and strain into a chilled white wine glass filled with ice
+May Daisy,Lemon Juice,1oz,Build,Wine,Shake with ice and strain into a chilled white wine glass filled with ice
+May Daisy,Mint Sprig,1,Garnish,Wine,Shake with ice and strain into a chilled white wine glass filled with ice
+May Daisy,Green Chartreuse,.75oz,Build,Wine,Shake with ice and strain into a chilled white wine glass filled with ice
+May Daisy,Simple Syrup,.75oz,Build,Wine,Shake with ice and strain into a chilled white wine glass filled with ice
+May Day,Fee Brothers Rhubarb Bitters,3dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+May Day,Moet Imperial Champagne,2oz,Top,Coupe,Stir with ice and strain into a chilled coupe
+May Day,Simple Syrup,1barspoon,Build,Coupe,Stir with ice and strain into a chilled coupe
+May Day,Aperol,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+May Day,Lemon Juice,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+May Day,Plymouth Gin,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Melon Stand,Watermelon Ball,3,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Melon Stand,Plymouth Gin,2oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Melon Stand,Watermelon Juice,1oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Melon Stand,Lemon Juice,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Melon Stand,Aperol,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Melon Stand,Simple Syrup,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Mexicano,Cucumber Slice,3,Muddle,Coupe,Stir with ice and fine-strain into a chilled coupe
+Mexicano,Moet Imperial Champagne,2oz,Top,Coupe,Stir with ice and fine-strain into a chilled coupe
+Mexicano,Partida Reposado Tequila,1.5oz,Build,Coupe,Stir with ice and fine-strain into a chilled coupe
+Mexicano,Lemon Twist,1,Garnish,Coupe,Stir with ice and fine-strain into a chilled coupe
+Mexicano,Gran Classico Bitter,.75oz,Build,Coupe,Stir with ice and fine-strain into a chilled coupe
+Mezcal Mule,Cucumber Slice,3,Muddle,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Mezcal Mule,House Ginger Beer,1oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Mezcal Mule,Sombra Mezcal,1.5oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Mezcal Mule,Candied Ginger,1,Garnish,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Mezcal Mule,Cucumber Slice,1,Garnish,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Mezcal Mule,Pinch Ground Chili,1,Garnish,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Mezcal Mule,Boiron Passion Fruit Puree,.75oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Mezcal Mule,Lime Juice,.75oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Mezcal Mule,Agave Syrup,.5oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Midnight Express,Freshly Brewed Coffee,3oz,Build,Mug,Add everything to a pre-heated heatproof mug and stir
+Midnight Express,Walnut-Infused Hine V.S.O.P. Cognac,1.5oz,Build,Mug,Add everything to a pre-heated heatproof mug and stir
+Midnight Express,Pinch Grated Nutmeg,1,Garnish,Mug,Add everything to a pre-heated heatproof mug and stir
+Midnight Express,Luxardo Amaretto,.25oz,Build,Mug,Add everything to a pre-heated heatproof mug and stir
+Midnight Express,Simple Syrup,.25oz,Build,Mug,Add everything to a pre-heated heatproof mug and stir
+Midnight Express,Freshly Whipped Cream,,Garnish,Mug,Add everything to a pre-heated heatproof mug and stir
+Milk Punch,Myers's Dark Rum,1oz,Build,Rocks,Shake with ice and strain over one large cube into a chilled rocks glass
+Milk Punch,Pierre Ferrand Ambre Cognac,1oz,Build,Rocks,Shake with ice and strain over one large cube into a chilled rocks glass
+Milk Punch,Whole Milk,1.5oz,Build,Rocks,Shake with ice and strain over one large cube into a chilled rocks glass
+Milk Punch,Pinch Grated Nutmeg,1,Garnish,Rocks,Shake with ice and strain over one large cube into a chilled rocks glass
+Milk Punch,Simple Syrup,.75oz,Build,Rocks,Shake with ice and strain over one large cube into a chilled rocks glass
+Mint Apple Crisp,Granny Smith Apple Slice,3,Muddle,Coupe,Stir with ice and fine-strain into a chilled coupe
+Mint Apple Crisp,Honeydew Melon Ball,3,Garnish,Coupe,Stir with ice and fine-strain into a chilled coupe
+Mint Apple Crisp,Heart of the Hudson Apple Vodka,2oz,Build,Coupe,Stir with ice and fine-strain into a chilled coupe
+Mint Apple Crisp,Mint Leaf,2,Muddle,Coupe,Stir with ice and fine-strain into a chilled coupe
+Mint Apple Crisp,Masumi Arabashiri Sake,1oz,Build,Coupe,Stir with ice and fine-strain into a chilled coupe
+Mint Apple Crisp,Simple Syrup,.25oz,Build,Coupe,Stir with ice and fine-strain into a chilled coupe
+Mint Julep,Mint Leaf,8,Muddle,Julep Cup,"Add everything to chilled julep cup, then pebble ice and swizzle then add more pebble ice and swizzle again"
+Mint Julep,Mint Leaf,3,Garnish,Julep Cup,"Add everything to chilled julep cup, then pebble ice and swizzle then add more pebble ice and swizzle again"
+Mint Julep,Booker's Bourbon,2.5oz,Build,Julep Cup,"Add everything to chilled julep cup, then pebble ice and swizzle then add more pebble ice and swizzle again"
+Mint Julep,Simple Syrup,.5oz,Build,Julep Cup,"Add everything to chilled julep cup, then pebble ice and swizzle then add more pebble ice and swizzle again"
+Mojito,Mint Leaf,8,Muddle,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Mojito,Banks 5 Island Rum,2oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Mojito,Club Soda,1oz,Top,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Mojito,Simple Syrup,1oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Mojito,Mint Sprig,1,Garnish,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Mojito,Lime Juice,.75oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Monkey Gland,Beefeater Gin,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Monkey Gland,Orange Juice,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Monkey Gland,Al Wadi Pomegranate Molasses,1barspoon,Build,Coupe,Shake with ice and strain into a chilled coupe
+Monkey Gland,Vieux Pontarlier Absinthe,,Rinse,Coupe,Shake with ice and strain into a chilled coupe
+Montgomery Smith,Hine V.S.O.P. Cognac,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Montgomery Smith,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Montgomery Smith,Benedictine,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Montgomery Smith,Fernet Branca,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Morango Fizz,Strawberry-Infused Mae de Ouro Cachaca,2oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Morango Fizz,Club Soda,1oz,Top,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Morango Fizz,Egg White,1,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Morango Fizz,Lemon Juice,.75oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Morango Fizz,Simple Syrup,.75oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Moscow Mule,House Ginger Beer,1oz,Build,Mule Cup,Shake with ice and strain into a chilled mule cup filled with ice
+Moscow Mule,Simple Syrup,1oz,Build,Mule Cup,Shake with ice and strain into a chilled mule cup filled with ice
+Moscow Mule,Smirnoff Black Vodka,1.5oz,Build,Mule Cup,Shake with ice and strain into a chilled mule cup filled with ice
+Moscow Mule,Candied Ginger,1,Garnish,Mule Cup,Shake with ice and strain into a chilled mule cup filled with ice
+Moscow Mule,Lime Wheel,1,Garnish,Mule Cup,Shake with ice and strain into a chilled mule cup filled with ice
+Moscow Mule,Lime Juice,.75oz,Build,Mule Cup,Shake with ice and strain into a chilled mule cup filled with ice
+Mount Vernon,Brandied Cherry,3,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Mount Vernon,Clear Creek Kirschwasser,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Mount Vernon,Gran Duque D'Alba Brandy de Jerez,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Mount Vernon,Grapefruit Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Mount Vernon,Cherry Heering,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Mount Vernon,Lustau Pedro Ximenez Sherry,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Mum's Apple Pie,Red Jacket Orchards Apple Cider,1oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Mum's Apple Pie,Havana Club 7-Year-Old Rum,1.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Mum's Apple Pie,Apple Slice,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Mum's Apple Pie,Pinch Grated Cinnamon,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Mum's Apple Pie,Pinch Grated Nutmeg,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Mum's Apple Pie,Lemon Juice,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Mum's Apple Pie,Demerara Syrup,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Navy Grog,Appleton Estate Reserve Rum,1oz,Build,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Navy Grog,El Dorado 15-Year-Old Rum,1oz,Build,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Navy Grog,Gosling's Black Seal Rum,1oz,Build,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Navy Grog,Grapefruit Juice,.75oz,Build,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Navy Grog,Lime Juice,.75oz,Build,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Navy Grog,Honey Syrup,.5oz,Build,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Negroni,Beefeater Gin,1.25oz,Build,Coupe/Rocks,Stir with ice and strain into a chilled coupe or over ice in a chilled rocks glass
+Negroni,Campari,1.25oz,Build,Coupe/Rocks,Stir with ice and strain into a chilled coupe or over ice in a chilled rocks glass
+Negroni,Martini Sweet Vermouth,1.25oz,Build,Coupe/Rocks,Stir with ice and strain into a chilled coupe or over ice in a chilled rocks glass
+Negroni,Orange Twist,1,Garnish,Coupe/Rocks,Stir with ice and strain into a chilled coupe or over ice in a chilled rocks glass
+New Amsterdam,Bols Genever,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+New Amsterdam,Peychaud's Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+New Amsterdam,Clear Creek Kirschwasser,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+New Amsterdam,Demerara Syrup,1barspoon,Build,Coupe,Stir with ice and strain into a chilled coupe
+New Amsterdam,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+New York Flip,Noval Black Port,2oz,Top,Coupe,"Dry-shake, then shake with ice and strain into a chilled coupe"
+New York Flip,Elijah Craig 12-Year-Old Bourbon,1oz,Build,Coupe,"Dry-shake, then shake with ice and strain into a chilled coupe"
+New York Flip,Egg Yolk,1,Build,Coupe,"Dry-shake, then shake with ice and strain into a chilled coupe"
+New York Flip,Pinch Grated Nutmeg,1,Garnish,Coupe,"Dry-shake, then shake with ice and strain into a chilled coupe"
+New York Flip,Heavy Cream,.5oz,Build,Coupe,"Dry-shake, then shake with ice and strain into a chilled coupe"
+New York Flip,Simple Syrup,.25oz,Build,Coupe,"Dry-shake, then shake with ice and strain into a chilled coupe"
+Newark,Laird's Bonded Apple Brandy,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Newark,Vya Sweet Vermouth,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Newark,Fernet Branca,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Newark,Maraska Maraschino Liqueur,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Newfangled,Brandied Cherry,3,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Newfangled,Old Grand-Dad Bonded Bourbon,2oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Newfangled,Southampton Double White Ale,2oz,Top,Coupe,Shake with ice and fine-strain into a chilled coupe
+Newfangled,Angostura Bitters,2dashes,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Newfangled,Orange,.5wheel,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Newfangled,Simple Syrup,.25oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Nigori Milk Punch,Feldman's Barrel Aged Bitters,3dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Nigori Milk Punch,Kamoizumi Nigori Sake,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Nigori Milk Punch,Hine V.S.O.P. Cognac,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Nigori Milk Punch,Pinch Grated Nutmeg,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Nigori Milk Punch,Navan Vanilla Liqueur,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Noce Royale,Moet Imperial Champagne,2oz,Top,Coupe,Stir with ice and strain into a chilled coupe
+Noce Royale,Beefeater Gin,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Noce Royale,Plymouth Sloe Gin,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Noce Royale,Monteverdi Nocino,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Norman Inversion,Dupont Brut Sparkling Cider,2oz,Top,Coupe,Shake with ice and strain into a chilled coupe
+Norman Inversion,Aviation Gin,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Norman Inversion,Regan's Orange Bitters,1dash,Build,Coupe,Shake with ice and strain into a chilled coupe
+Norman Inversion,Schonauer Apfel Schnapps,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Norman Inversion,Grapefruit Juice,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Norman Inversion,Simple Syrup,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Nouveau Carre,Peychaud's Bitters,3dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Nouveau Carre,Ocho Anejo Tequila,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Nouveau Carre,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Nouveau Carre,Lillet Blanc,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Nouveau Carre,Benedictine,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Nouveau Sangaree,Beaujolais Nouveau,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Nouveau Sangaree,Angostura Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Nouveau Sangaree,Laird's Bonded Apple Brandy,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Nouveau Sangaree,Apple Fan,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Nouveau Sangaree,Pinch Grated Cinnamon,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Nouveau Sangaree,Plymouth Sloe Gin,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Nouveau Sangaree,Deep Mountain Grade B Maple Syrup,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Noval Cup,Club Soda,2oz,Top,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Noval Cup,Noval Black Port,2oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Noval Cup,Cucumber Wheel,1,Garnish,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Noval Cup,Strawberry,1,Muddle,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Noval Cup,Lemon Juice,.5oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Noval Cup,Simple Syrup,.5oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Nth Degree,Fee Brothers Whiskey Barrel Aged Bitters,2dashes,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Nth Degree,Laird's Bonded Apple Brandy,1oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Nth Degree,Rhum Clement V.S.O.P.,1oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Nth Degree,Demerara Sugar Cube,1,Muddle,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Nth Degree,Lemon Twist,1,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Nth Degree,Orange Twist,1,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Nth Degree,Green Chartreuse,.5oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Occidental,Linie Aquavit,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Occidental,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Occidental,Grand Marnier,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Occidental,Nonino Amaro,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Occidental,Fernet Branca,,Rinse,Coupe,Stir with ice and strain into a chilled coupe
+Old Flame,Plymouth Gin,2oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Old Flame,Egg White,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Old Flame,Lemon Juice,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Old Flame,Simple Syrup,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Old Flame,Green Chartreuse V.E.P.,.5oz,Flame,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Old Maid,Mint Leaf,6,Muddle,Rocks,Shake with ice and fine-strain over one large cube into a chilled rocks glass
+Old Maid,Cucumber Slice,3,Muddle,Rocks,Shake with ice and fine-strain over one large cube into a chilled rocks glass
+Old Maid,Plymouth Gin,2oz,Build,Rocks,Shake with ice and fine-strain over one large cube into a chilled rocks glass
+Old Maid,Lime Juice,1oz,Build,Rocks,Shake with ice and fine-strain over one large cube into a chilled rocks glass
+Old Maid,Cucumber Slice,1,Garnish,Rocks,Shake with ice and fine-strain over one large cube into a chilled rocks glass
+Old Maid,Mint Sprig,1,Garnish,Rocks,Shake with ice and fine-strain over one large cube into a chilled rocks glass
+Old Maid,Simple Syrup,.75oz,Build,Rocks,Shake with ice and fine-strain over one large cube into a chilled rocks glass
+Old Pal,Old Overholt Rye Whiskey,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Old Pal,Campari,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Old Pal,Dolin Dry Vermouth,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Old-Fashioned Whiskey Cocktail,Wild Turkey Rye Whiskey,2oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Old-Fashioned Whiskey Cocktail,Angostura Bitters,2dashes,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Old-Fashioned Whiskey Cocktail,Demerara Sugar Cube,1,Muddle,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Old-Fashioned Whiskey Cocktail,Lemon Twist,1,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Opera Cocktail,Plymouth Gin,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Opera Cocktail,Dubonnet Rouge,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Opera Cocktail,House Orange Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Opera Cocktail,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Opera Cocktail,Mandarin Napoleon,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Paddington,Banks 5 Island Rum,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Paddington,Grapefruit Twist,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Paddington,Grapefruit Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Paddington,Lemon Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Paddington,Lillet Blanc,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Paddington,Bonne Maman Orange Marmalade,1barspoon,Build,Coupe,Shake with ice and strain into a chilled coupe
+Paddington,St. George Absinthe,,Rinse,Coupe,Shake with ice and strain into a chilled coupe
+Paddy Wallbanger,House Orange Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Paddy Wallbanger,Black Bush Irish Whiskey,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Paddy Wallbanger,Dolin Dry Vermouth,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Paddy Wallbanger,Galliano L'Autentico,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Paloma,Siete Leguas Reposado Tequila,2oz,Build,Collins,"Build in a chilled Collins glass, then add ice"
+Paloma,Ting Grapefruit Soda,2oz,Top,Collins,"Build in a chilled Collins glass, then add ice"
+Paloma,Half a Grapefruit Wheel,1,Garnish,Collins,"Build in a chilled Collins glass, then add ice"
+Paloma,Lime Juice,.5oz,Build,Collins,"Build in a chilled Collins glass, then add ice"
+Paloma,Salt,,Rim,Collins,"Build in a chilled Collins glass, then add ice"
+Parkside Fizz,Mint Leaf,8,Muddle,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Parkside Fizz,Hangar One Buddha's Hand Vodka,2oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Parkside Fizz,Club Soda,1oz,Top,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Parkside Fizz,Mint Sprig,1,Garnish,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Parkside Fizz,Lemon Juice,.75oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Parkside Fizz,Kassatly Chtaura Orgeat,.5oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Paul's Club Cocktail,Tanqueray Gin,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Paul's Club Cocktail,Concord Shrubb,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Paul's Club Cocktail,Ricard Pastis,.25oz,Float,Coupe,Stir with ice and strain into a chilled coupe
+Paul's Club Cocktail,Simple Syrup,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Pearl Button,Mae de Ouro Cachaca,2oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pearl Button,San Pellegrino Limonata,1.5oz,Top,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pearl Button,Half a Grapefruit Wheel,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pearl Button,Lillet Blanc,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pearl Button,Lime Juice,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pearl of Puebla,Oregano Sprig,4,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Pearl of Puebla,Sombra Mezcal,2oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Pearl of Puebla,Agave Nectar,1barspoon,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Pearl of Puebla,Ricard Pastis,1barspoon,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Pearl of Puebla,Lime Juice,.75oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Pearl of Puebla,Yellow Chartreuse,.75oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Perfect Pear,Clear Creek Pear Brandy,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Perfect Pear,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Perfect Pear,Orange Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Perfect Pear,Simple Syrup,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Perfect Pear,Sugar,,Rim,Coupe,Shake with ice and strain into a chilled coupe
+Persephone,Laird's Applejack,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Persephone,Dolin Sweet Vermouth,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Persephone,Lemon Juice,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Persephone,Plymouth Sloe Gin,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Persephone,Simple Syrup,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Pharaoh Cooler,Marivani Rose Flower Water,4drops,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pharaoh Cooler,Club Soda,1oz,Top,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pharaoh Cooler,Watermelon Juice,1oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pharaoh Cooler,Partida Blanco Tequila,1.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pharaoh Cooler,House Grenadine,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pharaoh Cooler,Lime Juice,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pimms Cup,Cucumber Slice,3,Muddle,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pimms Cup,Pimm's No. 1 Cup,2oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pimms Cup,Fever-Tree Ginger Ale,1oz,Top,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pimms Cup,Cucumber Slice,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pimms Cup,Lemon Juice,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pimms Cup,Simple Syrup,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Pink Lady,Plymouth Gin,1.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Pink Lady,Egg White,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Pink Lady,Lemon Juice,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Pink Lady,House Grenadine,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Pink Lady,Laird's Applejack,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Pink Lady,Simple Syrup,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Pisco Sour,Angostura Bitters,4drops,Garnish,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Pisco Sour,La Diablada Pisco,2oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Pisco Sour,Egg White,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Pisco Sour,Lime Juice,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Pisco Sour,Simple Syrup,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Platanos en Mole Old Fashioned,Ron Zacapa 23 Centenario Rum,2oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Platanos en Mole Old Fashioned,Bittermens Xocolatl Mole Bitters,12drops,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Platanos en Mole Old Fashioned,Pinch Ground Chili,1,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Platanos en Mole Old Fashioned,Marie Brizard Creme de Banane,.25oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Primavera,Krogstad Aquavit,2oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Primavera,Asparagus Tip,2,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Primavera,Celery Stalk,1,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Primavera,Fennel Bulb Slice,1,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Primavera,Orange Twist,1,Garnish,Coupe,Shake with ice and fine-strain into a chilled coupe
+Primavera,Cointreau,.75oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Primavera,Lemon Juice,.75oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Primavera,St. George Absinthe,,Rinse,Coupe,Shake with ice and fine-strain into a chilled coupe
+Prince Edward,Compass Box Oak Cross Blended Malt Scotch Whisky,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Prince Edward,House Orange Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Prince Edward,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Prince Edward,Lillet Blanc,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Prince Edward,Drambuie,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Prince of Wales,Blandy's Sercial Madeira,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Prince of Wales,Hine V.S.O.P. Cognac,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Prince of Wales,Moet Imperial Champagne,1oz,Top,Coupe,Stir with ice and strain into a chilled coupe
+Prince of Wales,Angostura Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Prince of Wales,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Prince of Wales,Grand Marnier,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Professor,Rhum Clement V.S.O.P.,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Professor,Angostura Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Professor,House Orange Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Professor,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Professor,Dow's Tawny Port,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Professor,Carpano Antica Sweet Vermouth,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Pumpkin Toddy,Angostura Bitters,2dashes,Build,Mug,Add everything to a pre-heated heatproof mug and stir
+Pumpkin Toddy,Libby's Pumpkin Puree,1tsp,Build,Mug,Add everything to a pre-heated heatproof mug and stir
+Pumpkin Toddy,Laird's Bonded Apple Brandy,1oz,Build,Mug,Add everything to a pre-heated heatproof mug and stir
+Pumpkin Toddy,Pinch Grated Cinnamon,1,Garnish,Mug,Add everything to a pre-heated heatproof mug and stir
+Pumpkin Toddy,Deep Mountain Grade B Maple Syrup,.5oz,Build,Mug,Add everything to a pre-heated heatproof mug and stir
+Pumpkin Toddy,Hot Water,.5oz,Top,Mug,Add everything to a pre-heated heatproof mug and stir
+Pumpkin Toddy,Lemon Juice,.5oz,Build,Mug,Add everything to a pre-heated heatproof mug and stir
+Pumpkin Toddy,Rittenhouse Bonded Rye Whiskey,.5oz,Build,Mug,Add everything to a pre-heated heatproof mug and stir
+Queen Park Swizzle,Mint Leaf,8,Muddle,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Queen Park Swizzle,Barbancourt 8-Year-Old Rhum,2oz,Build,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Queen Park Swizzle,Angostura Bitters,2dashes,Top,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Queen Park Swizzle,Peychaud's Bitters,2dashes,Top,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Queen Park Swizzle,Lime Juice,1oz,Build,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Queen Park Swizzle,Mint Sprig,1,Garnish,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Queen Park Swizzle,Demerara Syrup,.5oz,Build,Collins,"Build in a chilled Collins glass, fill with pebble ice and swizzle, then add more ice"
+Rack & Rye,Angostura Bitters,2dashes,Build,Rocks,Stir with ice and strain into a chilled rocks glass filled with ice
+Rack & Rye,Angostura Orange Bitters,2dashes,Build,Rocks,Stir with ice and strain into a chilled rocks glass filled with ice
+Rack & Rye,Wild Turkey Russell's Reserve 6-Year-Old Rye Whiskey,1.5oz,Build,Rocks,Stir with ice and strain into a chilled rocks glass filled with ice
+Rack & Rye,Lemon Peel,1,Twist,Rocks,Stir with ice and strain into a chilled rocks glass filled with ice
+Rack & Rye,Orange Peel,1,Twist,Rocks,Stir with ice and strain into a chilled rocks glass filled with ice
+Rack & Rye,Rock Candy Swizzle,1,Garnish,Rocks,Stir with ice and strain into a chilled rocks glass filled with ice
+Rack & Rye,van Oosten Batavia Arrack,.75oz,Build,Rocks,Stir with ice and strain into a chilled rocks glass filled with ice
+Rack & Rye,Demerara Syrup,.25oz,Build,Rocks,Stir with ice and strain into a chilled rocks glass filled with ice
+Ramos Gin Fizz,Marivani Orange Flower Water,5drops,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Ramos Gin Fizz,Beefeater Gin,2oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Ramos Gin Fizz,Club Soda,1oz,Top,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Ramos Gin Fizz,Egg White,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Ramos Gin Fizz,Heavy Cream,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Ramos Gin Fizz,Simple Syrup,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Ramos Gin Fizz,Lemon Juice,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Ramos Gin Fizz,Lime Juice,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Rapscallion,Talisker 10-Year-Old Single Malt Scotch Whisky,2.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Rapscallion,Lemon Peel,1,Twist,Coupe,Stir with ice and strain into a chilled coupe
+Rapscallion,Lustau Pedro Ximenez Sherry,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Rapscallion,St. George Absinthe,,Rinse,Coupe,Stir with ice and strain into a chilled coupe
+Raspberries Reaching,Marivani Rose Flower Water,3drops,Build,Coupe,Stir with ice and strain into a chilled coupe
+Raspberries Reaching,"Tokaji Aszu 5 Puttonyos ""Red Label""",1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Raspberries Reaching,Trimbach Framboise,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Raspberries Reaching,Pink Rose Petal,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Raspberries Reaching,Pama Pomegranate Liqueur,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Rattlesnake,Rittenhouse Bonded Rye Whiskey,2oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Rattlesnake,Lemon Juice,1oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Rattlesnake,Egg White,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Rattlesnake,Simple Syrup,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Rattlesnake,Vieux Pontarlier Absinthe,,Rinse,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Red Devil,Dried Persimmon Slice,3,Muddle,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Red Devil,Bols Genever,2oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Red Devil,Fee Brothers Whiskey Barrel Aged Bitters,2dashes,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Red Devil,Jujube Tea-infused Vya Sweet Vermouth,1oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Red Devil,Cinnamon Stick,1,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Red-headed Saint,A.B. Smeby Verbena Bitters,4dashes,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Red-headed Saint,Peychaud's Bitters,4dashes,Top,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Red-headed Saint,Beleza Pura Cachaca,2oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Red-headed Saint,Lime Juice,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Red-headed Saint,Agave Syrup,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Red-headed Saint,Yellow Chartreuse,.25oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with pebble ice
+Remember Maine,Rhum Clement V.S.O.P.,2oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Remember Maine,Angostura Bitters,2dashes,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Remember Maine,Red Jacket Orchards Apple Cider,1.5oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Remember Maine,Apple Fan,1,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Remember Maine,Pinch Sea Salt,1,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Remember Maine,St. Elizabeth Allspice Dram,.25oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Remember the Maine,Wild Turkey Russell's Reserve 6-Year-Old Rye Whiskey,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Remember the Maine,Pernod,1barspoon,Build,Coupe,Stir with ice and strain into a chilled coupe
+Remember the Maine,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Remember the Maine,Carpano Antica Sweet Vermouth,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Remember the Maine,Cherry Heering,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Resting Point,Siete Leguas Reposado Tequila,1.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Resting Point,Strawberry,1,Garnish,Coupe,Shake with ice and fine-strain into a chilled coupe
+Resting Point,Strawberry,1,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Resting Point,Strawberry Fan,1,Garnish,Coupe,Shake with ice and fine-strain into a chilled coupe
+Resting Point,Agave Syrup,.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Resting Point,Lemon Juice,.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Resting Point,Punt e Mes,.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Resting Point,Yellow Chartreuse,.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Reverend Palmer,BlackTea-Infused Elijah Craig 12-Year-Old Bourbon,2oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Reverend Palmer,Angostura Bitters,2dashes,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Reverend Palmer,Lemon Twist,1,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Reverend Palmer,Lemon Syrup,.5oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Rhubarbarita,Lemon Juice,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Rhubarbarita,Partida Blanco Tequila,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Rhubarbarita,Grapefruit Twist,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Rhubarbarita,Grand Marnier,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Rhubarbarita,Boiron Rhubarb Puree,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Rhubarbarita,House Grenadine,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Rhum Club,Banks 5 Island Rum,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Rhum Club,Angostura Bitters,2dashes,Build,Coupe,Shake with ice and strain into a chilled coupe
+Rhum Club,Angostura Orange Bitters,1dash,Build,Coupe,Shake with ice and strain into a chilled coupe
+Rhum Club,Orange Wedge,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Rhum Club,Lime Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Rhum Club,Rhum Clement Creole Shrubb,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Rhum Club,Martinique Sugar Cane Syrup,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Rio Bravo,Freshly Peeled Ginger Slice,3,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Rio Bravo,Sagatiba Cachaca,2oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Rio Bravo,Orange Twist,1,Garnish,Coupe,Shake with ice and fine-strain into a chilled coupe
+Rio Bravo,Lime Juice,.75oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Rio Bravo,Kassatly Chtaura Orgeat,.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Rite of Spring,Tanqueray Gin,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Rite of Spring,Pickled Ramps,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Rite of Spring,Vya Dry Vermouth,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Rite of Spring,Pickled Ramp Brine,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Rob Roy,Angostura Orange Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Rob Roy,Famous Grouse Blended Scotch Whisky,2.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Rob Roy,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Rob Roy,Dolin Sweet Vermouth,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Romeo Y Julieta,Aftel Tobacco Essence,4,Spritz,Coupe,Stir with ice and strain into a chilled coupe
+Romeo Y Julieta,Ron Zacapa Centenario 23 Rum,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Romeo Y Julieta,Campari,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Romeo Y Julieta,Carpano Antica Sweet Vermouth,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Rose,Brandied Cherry,3,Garnish,Coupe,Stir with ice and fine-strain into a chilled coupe
+Rose,Noilly Prat Dry Vermouth,2oz,Build,Coupe,Stir with ice and fine-strain into a chilled coupe
+Rose,Clear Creek Kirschwasser,1oz,Build,Coupe,Stir with ice and fine-strain into a chilled coupe
+Rose,Bonne Maman Raspberry Preserves,1barspoon,Build,Coupe,Stir with ice and fine-strain into a chilled coupe
+Rosita,Angostura Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Rosita,Partida Reposado Tequila,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Rosita,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Rosita,Campari,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Rosita,Dolin Dry Vermouth,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Rosita,Martini Sweet Vermouth,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Royal Bermuda Yachtclub Cocktail,Mount Gay Eclipse Amber Rum,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Royal Bermuda Yachtclub Cocktail,Lime Juice,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Royal Bermuda Yachtclub Cocktail,Lime Wheel,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Royal Bermuda Yachtclub Cocktail,Cointreau,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Royal Bermuda Yachtclub Cocktail,John D. Taylor's Velvet Falernum,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Rust Belt,Angostura Bitters,2,Spritz,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Rust Belt,Barbancourt 8-Year-Old Rhum,1.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Rust Belt,Egg White,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Rust Belt,Lemon Juice,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Rust Belt,Lime Juice,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Rust Belt,Navan Vanilla Liqueur,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Rust Belt,Kassatly Chtaura Orgeat,.25oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Rusty Nail,Famous Grouse Blended Scotch Whisky,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Rusty Nail,Drambuie,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Rye Witch,Rittenhouse Bonded Rye Whiskey,2oz,Build,Rocks,Stir with ice and strain into a chilled rocks glass
+Rye Witch,House Orange Bitters,2dashes,Build,Rocks,Stir with ice and strain into a chilled rocks glass
+Rye Witch,Orange Peel,1,Twist,Rocks,Stir with ice and strain into a chilled rocks glass
+Rye Witch,Sugar Cube,1,Muddle,Rocks,Stir with ice and strain into a chilled rocks glass
+Rye Witch,Lustau Palo Cortado Sherry,.25oz,Build,Rocks,Stir with ice and strain into a chilled rocks glass
+Rye Witch,Strega,.25oz,Build,Rocks,Stir with ice and strain into a chilled rocks glass
+Sage Old Buck,Whole Black Peppercorn,8,Muddle,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Sage Old Buck,Benromach 12-Year-Old Single Malt Scotch Whisky,1.5oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Sage Old Buck,Sage Leaf,1,Garnish,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Sage Old Buck,House Ginger Beer,.75oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Sage Old Buck,Lemon Juice,.75oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Sage Old Buck,Simple Syrup,.75oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Sage Old Buck,Belle de Brillet,.5oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Sage Old Buck,Eurovanille Vanilla Syrup,.25oz,Build,Collins,Shake with ice and fine-strain into a chilled Collins glass filled with ice
+Sazerac,Peychaud's Bitters,3dashes,Build,Rocks,Stir with ice and strain into a chilled rocks glass
+Sazerac,Rittenhouse Bonded Rye Whiskey,2oz,Build,Rocks,Stir with ice and strain into a chilled rocks glass
+Sazerac,Angostura Bitters,2dashes,Build,Rocks,Stir with ice and strain into a chilled rocks glass
+Sazerac,Demerara Sugar Cube,1,Muddle,Rocks,Stir with ice and strain into a chilled rocks glass
+Sazerac,Lemon Peel,1,Twist,Rocks,Stir with ice and strain into a chilled rocks glass
+Sazerac,Vieux Pontarlier Absinthe,,Rinse,Rocks,Stir with ice and strain into a chilled rocks glass
+Seelbach Cocktail,Peychaud's Bitters,3dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Seelbach Cocktail,Moet Imperial Champagne,2oz,Top,Coupe,Stir with ice and strain into a chilled coupe
+Seelbach Cocktail,Angostura Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Seelbach Cocktail,Bulleit Bourbon,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Seelbach Cocktail,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Seelbach Cocktail,Cointreau,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Shaddock Rose,El Tesoro Reposado Tequila,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Shaddock Rose,House Orange Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Shaddock Rose,Peychaud's Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Shaddock Rose,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Shaddock Rose,Small Hand Foods Grapefruit Cordial,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Shiso Delicious,Shiso Leaves,2,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Shiso Delicious,Aviation Gin,1.75oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Shiso Delicious,Red Bell Pepper Slice,1,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Shiso Delicious,Lemon Juice,.75oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Shiso Delicious,Grapefruit Juice,.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Shiso Delicious,Martinique Sugar Cane Syrup,.25oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Shiso Malt Sour,Yamazaki 12-Year-Old Japanese Single Malt Whisky,2oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Shiso Malt Sour,Shiso Leaves,2,Muddle,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Shiso Malt Sour,Egg White,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Shiso Malt Sour,Shiso Leaves,1,Garnish,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Shiso Malt Sour,Lime Juice,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Shiso Malt Sour,Simple Syrup,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Shiso Malt Sour,Vieux Pontarlier Absinthe,.25oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Sidecar,Remy Martin V.S.O.P. Cognac,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Sidecar,Cointreau,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Sidecar,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Sidecar,Simple Syrup,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Sidecar,Sugar,,Rim,Coupe,Shake with ice and strain into a chilled coupe
+Siesta,El Tesoro Reposado Tequila,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Siesta,Grapefruit Twist,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Siesta,Campari,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Siesta,Grapefruit Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Siesta,Lime Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Siesta,Simple Syrup,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Silk Road,Black Sesame-Infused Krogstad Aquavit,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Silk Road,Angostura Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Silk Road,Peychaud's Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Silk Road,Flamed Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Silk Road,Caramelized Simple Syrup,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Silver Lining,Club Soda,1oz,Top,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Silver Lining,Old Overholt Rye Whiskey,1.5oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Silver Lining,Egg White,1,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Silver Lining,Lemon Juice,.75oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Silver Lining,Licor 43,.75oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Silver Lining,Simple Syrup,.25oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Silver Root Beer Fizz,Fitz's Root Beer,2oz,Top,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Silver Root Beer Fizz,Mount Gay Eclipse White Rum,1oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Silver Root Beer Fizz,Smith & Cross Jamaican Rum,1oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Silver Root Beer Fizz,Egg White,1,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Silver Root Beer Fizz,Pinch Grated Nutmeg,1,Garnish,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Silver Root Beer Fizz,Lemon Juice,.5oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Silver Root Beer Fizz,Pineapple Juice,.5oz,Build,Fizz,"Dry-shake, then shake with ice and strain into a chilled fizz glass"
+Silver Sangaree,Kirsch Brandied Cherry,4,Muddle,Wine,"Dry-shake, then shake with ice and strain into a chilled wine glass"
+Silver Sangaree,Paumanok Cabernet Franc,1.5oz,Build,Wine,"Dry-shake, then shake with ice and strain into a chilled wine glass"
+Silver Sangaree,Egg White,1,Build,Wine,"Dry-shake, then shake with ice and strain into a chilled wine glass"
+Silver Sangaree,Pinch Grated Nutmeg,1,Garnish,Wine,"Dry-shake, then shake with ice and strain into a chilled wine glass"
+Silver Sangaree,Lemon Juice,.75oz,Build,Wine,"Dry-shake, then shake with ice and strain into a chilled wine glass"
+Silver Sangaree,Clove Syrup,.5oz,Build,Wine,"Dry-shake, then shake with ice and strain into a chilled wine glass"
+Silver Sangaree,Dow's Ruby Port,.5oz,Build,Wine,"Dry-shake, then shake with ice and strain into a chilled wine glass"
+Silver Sangaree,Famous Grouse Blended Scotch Whisky,.5oz,Build,Wine,"Dry-shake, then shake with ice and strain into a chilled wine glass"
+Singapore Sling,Pineapple Juice,2oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Singapore Sling,Angostura Bitters,1dash,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Singapore Sling,Plymouth Gin,1.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Singapore Sling,Cherry,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Singapore Sling,Pineapple Slice,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Singapore Sling,Cherry Heering,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Singapore Sling,House Grenadine,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Singapore Sling,Benedictine,.25oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Singapore Sling,Cointreau,.25oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Singapore Sling,Lime Juice,.25oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Single Malt Sangaree,Paumanok Cabernet Franc,2oz,Build,Mug,Heat everything and served in a pre-warmed heatproof mug
+Single Malt Sangaree,Dubonnet Rouge,1oz,Build,Mug,Heat everything and served in a pre-warmed heatproof mug
+Single Malt Sangaree,Oban 14-Year-Old Single Malt Scotch Whisky,1oz,Build,Mug,Heat everything and served in a pre-warmed heatproof mug
+Single Malt Sangaree,Demerara Syrup,1barspoon,Build,Mug,Heat everything and served in a pre-warmed heatproof mug
+Single Malt Sangaree,Cinnamon Stick,1,Garnish,Mug,Heat everything and served in a pre-warmed heatproof mug
+Single Malt Sangaree,Orange Peel,1,Twist,Mug,Heat everything and served in a pre-warmed heatproof mug
+Single Malt Sangaree,Grand Marnier,.75oz,Build,Mug,Heat everything and served in a pre-warmed heatproof mug
+Sloe Gin Fizz,Club Soda,3oz,Top,Fizz,Shake with ice and strain into a chilled fizz glass
+Sloe Gin Fizz,Plymouth Gin,1oz,Build,Fizz,Shake with ice and strain into a chilled fizz glass
+Sloe Gin Fizz,Plymouth Sloe Gin,1oz,Build,Fizz,Shake with ice and strain into a chilled fizz glass
+Sloe Gin Fizz,Lemon Juice,.75oz,Build,Fizz,Shake with ice and strain into a chilled fizz glass
+Sloe Gin Fizz,Simple Syrup,.25oz,Build,Fizz,Shake with ice and strain into a chilled fizz glass
+Smoky Grove,Compass Box Peat Monster Blended Malt Scotch Whisky,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Smoky Grove,Angostura Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Smoky Grove,House Orange Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Smoky Grove,Flamed Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Smoky Grove,Carpano Antica Sweet Vermouth,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Smoky Grove,Dolin Dry Vermouth,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Solstice,Rittenhouse Bonded Rye Whiskey,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Solstice,Dubonnet Rouge,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Solstice,Laird's Bonded Apple Brandy,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Solstice,Nonino Amaro,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Solstice,House Grenadine,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+South Slope,Lemon Twist,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+South Slope,Aperol,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+South Slope,Beefeater Gin,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+South Slope,Lillet Blanc,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+South Slope,Lemon Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+South Slope,Marie Brizard Orange Curacao,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Southside,Mint Leaf,4,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Southside,Plymouth Gin,2oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Southside,Lemon Juice,.75oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Southside,Simple Syrup,.75oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Spice Market,Masumi Arabashiri Sake,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Spice Market,Beefeater 24 Gin,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Spice Market,John D. Taylor's Velvet Falernum,1barspoon,Build,Coupe,Stir with ice and strain into a chilled coupe
+Spice Market,Aftel Clove Essence,1,Spritz,Coupe,Stir with ice and strain into a chilled coupe
+St. Rita,Moet Imperial Champagne,2oz,Top,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+St. Rita,Clear Creek Plum Brandy,1.5oz,Build,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+St. Rita,Edible Orchid,1,Garnish,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+St. Rita,Marivani Lavender Essence,1,Spritz,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+St. Rita,Lime Juice,.75oz,Build,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+St. Rita,Honey Syrup,.5oz,Build,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+St. Rita,Zwack,.5oz,Build,Egg Coupe,Shake with ice and strain into a chilled egg coupe
+Staggerac,Peychaud's Bitters,3dashes,Build,Rocks,Stir with ice and strain into a chilled rocks glass
+Staggerac,George T. Stagg Bourbon,2oz,Build,Rocks,Stir with ice and strain into a chilled rocks glass
+Staggerac,Angostura Bitters,2dashes,Build,Rocks,Stir with ice and strain into a chilled rocks glass
+Staggerac,Lemon Peel,1,Twist,Rocks,Stir with ice and strain into a chilled rocks glass
+Staggerac,Sugar Cube,1,Muddle,Rocks,Stir with ice and strain into a chilled rocks glass
+Staggerac,Edouard Absinthe,,Rinse,Rocks,Stir with ice and strain into a chilled rocks glass
+Statesman,Beefeater 24 Gin,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Statesman,Regan's Orange Bitters,1dash,Build,Coupe,Stir with ice and strain into a chilled coupe
+Statesman,Green Chartreuse,1barspoon,Build,Coupe,Stir with ice and strain into a chilled coupe
+Statesman,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Statesman,Rothman & Winter Orchard Pear,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Swiss Mist,Plymouth Gin,2oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Swiss Mist,Egg White,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Swiss Mist,Kubler Absinthe,1,Spritz,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Swiss Mist,Grapefruit Syrup,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Swiss Mist,Lemon Juice,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Swollen Gland,Peychaud's Bitters,4dashes,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Swollen Gland,Berkshire Mountain Distillers' Greylock Gin,2oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Swollen Gland,Cucumber Ribbon,1,Garnish,Coupe,Shake with ice and fine-strain into a chilled coupe
+Swollen Gland,Orange Juice,.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Swollen Gland,Yellow Chartreuse,.25oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Swollen Gland,Vieux Pontarlier Absinthe,,Rinse,Coupe,Shake with ice and fine-strain into a chilled coupe
+T&T,Angostura Bitters,2dashes,Build,Coupe,Shake with ice and strain into a chilled coupe
+T&T,Siembra Azul Blanco Tequila,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+T&T,Sombra Mezcal,1oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+T&T,Tamarind Puree,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+T&T,Orange Twist,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+T&T,Benedictine,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Talbott Leaf,Mint Leaf,6,Muddle,Coupe,Shake with ice and fine-strain into a chilled coupe
+Talbott Leaf,Old Grand-Dad Bonded Bourbon,2oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Talbott Leaf,Bonne Maman Strawberry Preserves,1barspoon,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Talbott Leaf,Mint Leaf,1,Garnish,Coupe,Shake with ice and fine-strain into a chilled coupe
+Talbott Leaf,Lemon Juice,.75oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Talbott Leaf,Green Chartreuse,.5oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Talbott Leaf,Cynar,.25oz,Build,Coupe,Shake with ice and fine-strain into a chilled coupe
+Tao of Pooh,Liquiteria Coconut Water,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Tao of Pooh,The Bitter Truth Lemon Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Tao of Pooh,42 Below Manuka Honey Vodka,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Tao of Pooh,Galliano L'Autentico,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+There Will Be Blood,Old Grand-Dad Bonded Bourbon,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+There Will Be Blood,Flamed Orange Twist,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+There Will Be Blood,Blood Orange Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+There Will Be Blood,Godiva Original Liqueur,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Tipperary Cocktail,Black Bush Irish Whiskey,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Tipperary Cocktail,Carpano Antica Sweet Vermouth,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Tipperary Cocktail,Green Chartreuse,,Rinse,Coupe,Stir with ice and strain into a chilled coupe
+Ti-Punch,Neisson Rhum Reserve Speciale,2oz,Build,Rocks,"Add everything to a chilled rocks glass, then top with pebble ice. Swizzle, then top with more pebble ice and swizzle again"
+Ti-Punch,Martinique Sugar Cane Syrup,1barspoon,Build,Rocks,"Add everything to a chilled rocks glass, then top with pebble ice. Swizzle, then top with more pebble ice and swizzle again"
+Ti-Punch,Lime Disc,1,Build,Rocks,"Add everything to a chilled rocks glass, then top with pebble ice. Swizzle, then top with more pebble ice and swizzle again"
+Tom Collins,Club Soda,2oz,Top,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Tom Collins,Hayman's Old Tom Gin,2oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Tom Collins,Lemon Wedge,1,Garnish,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Tom Collins,Lemon Juice,.75oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Tom Collins,Simple Syrup,.5oz,Build,Collins glass,Shake with ice and strain into a chilled Collins glass filled with ice
+Tommy's Margarita,L & J Blanco Tequila,2oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Tommy's Margarita,Agave Syrup,1oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Tommy's Margarita,Lime Juice,1oz,Build,Rocks,Shake with ice and strain into a chilled rocks glass filled with ice
+Triborough,Wild Turkey Rye Whiskey,2oz,Build,Rocks,Stir with ice and strain into a chilled rocks glass
+Triborough,Angostura Bitters,1dash,Build,Rocks,Stir with ice and strain into a chilled rocks glass
+Triborough,Orange Twist,1,Garnish,Rocks,Stir with ice and strain into a chilled rocks glass
+Triborough,Amaro Ciociaro,.5oz,Build,Rocks,Stir with ice and strain into a chilled rocks glass
+Triborough,Clear Creek Kirschwasser,.5oz,Build,Rocks,Stir with ice and strain into a chilled rocks glass
+Triborough,Punt e Mes,.5oz,Build,Rocks,Stir with ice and strain into a chilled rocks glass
+Trident,Fee Brothers Peach Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Trident,Krogstad Aquavit,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Trident,Lustau Manzanilla Sherry,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Trident,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Trident,Cynar,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Tuxedo,Plymouth Gin,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Tuxedo,House Orange Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Tuxedo,Dolin Dry Vermouth,1.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Tuxedo,Cherry,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Tuxedo,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Tuxedo,Luxardo Maraschino Liqueur,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Tuxedo,Vieux Pontarlier Absinthe,,Rinse,Coupe,Stir with ice and strain into a chilled coupe
+Up to Date,Wild Turkey Rye Whiskey,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Up to Date,Angostura Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Up to Date,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Up to Date,Lustau Manzanilla Sherry,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Up to Date,Grand Marnier,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Vaccari,The Bitter Truth Grapefruit Bitters,1dash,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Vaccari,The Bitter Truth Lemon Bitters,1dash,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Vaccari,Chamomile-Infused Compass Box Asyla Blended Scotch Whisky,1.5oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Vaccari,Grapefruit Twist,1,Garnish,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Vaccari,Dolin Dry Vermouth,.75oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Vaccari,Galliano L'Autentico,.5oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Vauvert Slim,Mint Leaf,6,Muddle,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Vauvert Slim,Grapefruit Juice,2oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Vauvert Slim,Green Chartreuse,1oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Vauvert Slim,Egg White,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Vauvert Slim,Mint Leaf,1,Garnish,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Vauvert Slim,Lime Juice,.5oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Vauvert Slim,Laphroaig 10-Year-Old Single Malt Scotch,,Rinse,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+Velvet Club,Hine V.S.O.P. Cognac,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Velvet Club,Moet Imperial Champagne,1oz,Top,Coupe,Stir with ice and strain into a chilled coupe
+Velvet Club,Lillet Blanc,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Velvet Club,Marie Brizard White Creme de Cacao,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Vesper,Plymouth Gin,2.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Vesper,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Vesper,Belvedere Vodka,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Vesper,Lillet Blanc,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Vieux Carre,Carpano Antica Sweet Vermouth,1oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Vieux Carre,Hine V.S.O.P. Cognac,1oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Vieux Carre,Sazerac 6-Year-Old Rye Whiskey,1oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Vieux Carre,Angostura Bitters,1dash,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Vieux Carre,Peychaud's Bitters,1dash,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Vieux Carre,Benedictine,.25oz,Build,Rocks,Stir with ice and strain over one large cube into a chilled rocks glass
+Vieux Mot,Plymouth Gin,1.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Vieux Mot,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Vieux Mot,Simple Syrup,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Vieux Mot,St. Germain Elderflower Liqueur,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Ward Eight,Rittenhouse Bonded Rye Whiskey,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Ward Eight,Al Wadi Pomegranate Molasses,1barspoon,Build,Coupe,Shake with ice and strain into a chilled coupe
+Ward Eight,Lemon Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Ward Eight,Orange Juice,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Ward Eight,Simple Syrup,.25oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Water Lily,Orange Twist,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Water Lily,Cointreau,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Water Lily,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Water Lily,Plymouth Gin,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Water Lily,Rothman & Winter Creme de Violette,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Weeski,Jameson 12-Year-Old Irish Whiskey,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Weeski,House Orange Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Weeski,Orange Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Weeski,Lillet Blanc,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Weeski,Cointreau,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Wellington Fizz,Diluted Aftel Bergamot Essence,3,Spritz,Collins,"Dry-shake, then shake with ice and strain into a chilled Collins glass"
+Wellington Fizz,42 Below Kiwi Vodka,2oz,Build,Collins,"Dry-shake, then shake with ice and strain into a chilled Collins glass"
+Wellington Fizz,Heavy Cream,1oz,Build,Collins,"Dry-shake, then shake with ice and strain into a chilled Collins glass"
+Wellington Fizz,Club Soda,1,Top,Collins,"Dry-shake, then shake with ice and strain into a chilled Collins glass"
+Wellington Fizz,Egg White,1,Build,Collins,"Dry-shake, then shake with ice and strain into a chilled Collins glass"
+Wellington Fizz,Lime Juice,.75oz,Build,Collins,"Dry-shake, then shake with ice and strain into a chilled Collins glass"
+Wellington Fizz,Boiron Passion Fruit Puree,.5oz,Build,Collins,"Dry-shake, then shake with ice and strain into a chilled Collins glass"
+Wellington Fizz,Kassatly Chtaura Orgeat,.5oz,Build,Collins,"Dry-shake, then shake with ice and strain into a chilled Collins glass"
+Whiskey Smash,Mint Leaf,6,Muddle,Rocks,Shake with ice and fine-strain into a chilled rocks glass filled with ice
+Whiskey Smash,Lemon Wedge,3,Muddle,Rocks,Shake with ice and fine-strain into a chilled rocks glass filled with ice
+Whiskey Smash,Rittenhouse Bonded Rye Whiskey,2oz,Build,Rocks,Shake with ice and fine-strain into a chilled rocks glass filled with ice
+Whiskey Smash,Mint Leaf,1,Garnish,Rocks,Shake with ice and fine-strain into a chilled rocks glass filled with ice
+Whiskey Smash,Simple Syrup,.75oz,Build,Rocks,Shake with ice and fine-strain into a chilled rocks glass filled with ice
+White Birch Fizz,Club Soda,2oz,Top,Collins,"Dry-shake, then shake with ice and strain into a chilled Collins glass"
+White Birch Fizz,Plymouth Gin,1.5oz,Build,Collins,"Dry-shake, then shake with ice and strain into a chilled Collins glass"
+White Birch Fizz,Egg White,1,Build,Collins,"Dry-shake, then shake with ice and strain into a chilled Collins glass"
+White Birch Fizz,Suze,1,Spritz,Collins,"Dry-shake, then shake with ice and strain into a chilled Collins glass"
+White Birch Fizz,Lemon Juice,.75oz,Build,Collins,"Dry-shake, then shake with ice and strain into a chilled Collins glass"
+White Birch Fizz,Rothman & Winter Orchard Apricot,.5oz,Build,Collins,"Dry-shake, then shake with ice and strain into a chilled Collins glass"
+White Birch Fizz,Strega,.5oz,Build,Collins,"Dry-shake, then shake with ice and strain into a chilled Collins glass"
+White Lady,Beefeater Gin,2oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+White Lady,Egg White,1,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+White Lady,Cointreau,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+White Lady,Lemon Juice,.75oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+White Lady,Simple Syrup,.25oz,Build,Egg Coupe,"Dry-shake, then shake with ice and strain into a chilled egg coupe"
+White Negroni,Plymouth Gin,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+White Negroni,Lillet Blanc,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+White Negroni,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+White Negroni,Suze,.75oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Widow's Kiss,Laird's Bonded Apple Brandy,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Widow's Kiss,Angostura Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Widow's Kiss,Benedictine,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Widow's Kiss,Yellow Chartreuse,.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Witch's Kiss,Jose Cuervo Platino Tequila,2oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Witch's Kiss,Red Jacket Orchards Apple Butter,1barspoon,Build,Coupe,Shake with ice and strain into a chilled coupe
+Witch's Kiss,Lemon Twist,1,Garnish,Coupe,Shake with ice and strain into a chilled coupe
+Witch's Kiss,Lemon Juice,.75oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Witch's Kiss,Strega,.5oz,Build,Coupe,Shake with ice and strain into a chilled coupe
+Woolworth,Compass Box Asyla Blended Scotch Whisky,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Woolworth,House Orange Bitters,2dashes,Build,Coupe,Stir with ice and strain into a chilled coupe
+Woolworth,Lustau Manzanilla Sherry,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Woolworth,Lemon Twist,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Woolworth,Benedictine,.5oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Wrong Aisle,Laird's Bonded Apple Brandy,2oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Wrong Aisle,Lillet Rouge,1oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Wrong Aisle,Apple Fan,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Wrong Aisle,Pinch Grated Nutmeg,1,Garnish,Coupe,Stir with ice and strain into a chilled coupe
+Wrong Aisle,Quince Shrubb (Huilerie Beaujolaise Vinaigre de Coing),.25oz,Build,Coupe,Stir with ice and strain into a chilled coupe
+Wrong Aisle,St. Germain Elderflower Liqueur,,Rinse,Coupe,Stir with ice and strain into a chilled coupe
+Zombie Punch,Lemon Hart Overproof Rum,1oz,Build,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with pebble ice
+Zombie Punch,Angostura Bitters,1dash,Build,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with pebble ice
+Zombie Punch,House Grenadine,1barspoon,Build,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with pebble ice
+Zombie Punch,Vieux Pontarlier Absinthe,1/8 tsp,Build,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with pebble ice
+Zombie Punch,Appleton Estate Reserve Rum,1.5oz,Build,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with pebble ice
+Zombie Punch,Bacardi 8 Rum,1.5oz,Build,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with pebble ice
+Zombie Punch,Mint Sprig,1,Garnish,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with pebble ice
+Zombie Punch,Lime Juice,.75oz,Build,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with pebble ice
+Zombie Punch,John D. Taylor's Velvet Falernum,.5oz,Build,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with pebble ice
+Zombie Punch,Trader Tiki's Don's Mix,.5oz,Build,Tiki Mug,Shake with ice and strain into a chilled tiki mug filled with pebble ice

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_14_233003) do
+ActiveRecord::Schema.define(version: 2018_05_15_003715) do
 
   create_table "cocktails", force: :cascade do |t|
     t.string "name"
@@ -21,14 +21,21 @@ ActiveRecord::Schema.define(version: 2018_05_14_233003) do
   end
 
   create_table "ingredients", force: :cascade do |t|
-    t.integer "recipe_id"
     t.string "name"
     t.string "generic_name"
-    t.string "ingredient_use"
-    t.string "amount"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["recipe_id"], name: "index_ingredients_on_recipe_id"
+  end
+
+  create_table "recipe_ingredients", force: :cascade do |t|
+    t.integer "recipe_id"
+    t.integer "ingredient_id"
+    t.string "ingredient_use"
+    t.string "amount"
+    t.index ["ingredient_id", "recipe_id"], name: "index_recipe_ingredients_on_ingredient_id_and_recipe_id"
+    t.index ["ingredient_id"], name: "index_recipe_ingredients_on_ingredient_id"
+    t.index ["recipe_id", "ingredient_id"], name: "index_recipe_ingredients_on_recipe_id_and_ingredient_id"
+    t.index ["recipe_id"], name: "index_recipe_ingredients_on_recipe_id"
   end
 
   create_table "recipes", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 2018_05_15_003715) do
   create_table "recipes", force: :cascade do |t|
     t.integer "cocktail_id"
     t.string "source"
+    t.string "directions"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["cocktail_id"], name: "index_recipes_on_cocktail_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,42 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2018_05_14_233003) do
+
+  create_table "cocktails", force: :cascade do |t|
+    t.string "name"
+    t.string "cocktail_type"
+    t.string "glass"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "ingredients", force: :cascade do |t|
+    t.integer "recipe_id"
+    t.string "name"
+    t.string "generic_name"
+    t.string "ingredient_use"
+    t.string "amount"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recipe_id"], name: "index_ingredients_on_recipe_id"
+  end
+
+  create_table "recipes", force: :cascade do |t|
+    t.integer "cocktail_id"
+    t.string "source"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["cocktail_id"], name: "index_recipes_on_cocktail_id"
+  end
+
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,67 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+require 'csv'
+
+# Seed database with PDT cocktail recipes
+PDT_CSV = "db/pdt_seed.csv"
+PDT_SOURCE_STRING = %q{Meehan, J., 2011. The PDT Cocktail Book: The Complete Bartender's Guide from the Celebrated Speakeasy. Sterling Epicure.}
+
+puts "Parsing data from PDT csv..."
+cocktails = {}
+CSV.foreach(PDT_CSV, {:headers => true}).each do |row|
+  if cocktails[row["Drink"]]
+    cocktails[row["Drink"]][:cocktail_items] ||= []
+    cocktails[row["Drink"]][:cocktail_items] << {
+      name: row["Ingredient"],
+      amount: row["Amount"],
+      ingredient_use: row["IngredientUse"]
+    }
+
+  else
+    cocktail_name = row["Drink"]
+    cocktails[cocktail_name] = {}
+    cocktails[cocktail_name][:glass]      = row["Glass"]
+    cocktails[cocktail_name][:directions] = row["HowToMix"]
+    if row["HowToMix"] =~ /shake/i
+      cocktails[cocktail_name][:cocktail_type] = "Shaken"
+    elsif row["HowToMix"] =~ /stir/i
+      cocktails[cocktail_name][:cocktail_type] = "Stirred"
+    elsif row["HowToMix"] =~ /swizzle/i
+      cocktails[cocktail_name][:cocktail_type] = "Swizzle"
+    elsif row["HowToMix"] =~ /build/i
+      cocktails[cocktail_name][:cocktail_type] = "Built"
+    end
+
+    cocktails[cocktail_name][:cocktail_items] = []
+    cocktails[cocktail_name][:cocktail_items] << {
+      name: row["Ingredient"],
+      amount: row["Amount"],
+      ingredient_use: row["IngredientUse"]
+    }
+  end
+end
+
+puts "Importing PDT data into database"
+cocktails.each do |cocktail_name, attributes|
+  print "."
+  cocktail = Cocktail.create(
+    name: cocktail_name,
+    cocktail_type: attributes[:cocktail_type],
+    glass: attributes[:glass],
+    # directions: attributes[:directions],
+  )
+
+  recipe = cocktail.recipes.create(source: PDT_SOURCE_STRING)
+
+  attributes[:cocktail_items].each do |cocktail_item|
+    ingredient = Ingredient.find_or_create_by(name: cocktail_item[:name])
+
+    RecipeIngredient.create(
+      ingredient_use: cocktail_item[:ingredient_use],
+      amount: cocktail_item[:amount],
+      recipe: recipe,
+      ingredient: ingredient,
+    )
+  end
+  cocktail.save
+end
+
+puts "done"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,10 +46,12 @@ cocktails.each do |cocktail_name, attributes|
     name: cocktail_name,
     cocktail_type: attributes[:cocktail_type],
     glass: attributes[:glass],
-    # directions: attributes[:directions],
   )
 
-  recipe = cocktail.recipes.create(source: PDT_SOURCE_STRING)
+  recipe = cocktail.recipes.create(
+    source: PDT_SOURCE_STRING,
+    directions: attributes[:directions],
+  )
 
   attributes[:cocktail_items].each do |cocktail_item|
     ingredient = Ingredient.find_or_create_by(name: cocktail_item[:name])

--- a/spec/models/cocktail_spec.rb
+++ b/spec/models/cocktail_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Cocktail, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/ingredient_spec.rb
+++ b/spec/models/ingredient_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Ingredient, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Recipe, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This is a first pass attempt at modeling Cocktail, Recipe, and Ingredients in ActiveRecord and GraphQL.

**The model diagram is attached at the bottom of this PR**

For GraphQL, i think I may not have setup this model in an efficient way. In order to search for a cocktail by name and return a list of ingredients I must execute the following query:
```
{
  cocktail(name: "Last Word") {
    name,
    recipes {
      directions,
      recipe_ingredients {
        amount,
        ingredient_use,
        ingredient {
          name
        }
      }
    }
  }
}
```
It definitely feels weird that i have to nest into the Ingredient type just to pull out the name of the Ingredient.

The resulting JSON hash is pretty gnarly too
```
{"cocktail"=>
  {"name"=>"Last Word",
   "recipes"=>
    [{"directions"=>"Shake with ice and strain into a chilled coupe",
      "recipe_ingredients"=>
       [{"amount"=>".75oz",
         "ingredient_use"=>"Build",
         "ingredient"=>{"name"=>"Green Chartreuse"}},
        {"amount"=>".75oz",
         "ingredient_use"=>"Build",
         "ingredient"=>{"name"=>"Lime Juice"}},
        {"amount"=>".75oz",
         "ingredient_use"=>"Build",
         "ingredient"=>{"name"=>"Luxardo Maraschino Liqueur"}},
        {"amount"=>".75oz",
         "ingredient_use"=>"Build",
         "ingredient"=>{"name"=>"Tanqueray Gin"}}]}]}}
````

Maybe the right approach here is to instead modify and clean up the output in the Query definition?

<img width="938" alt="models" src="https://user-images.githubusercontent.com/723637/40036180-722f902a-57cb-11e8-9011-8deae637874e.png">
