### PR TITLE
Add Brakeman step to CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ jobs:
       - run:
           name: Database setup
           command: bin/rails db:schema:load --trace
+
       # Run rspec in parallel
       - run:
           name: Run rspec in parallel
@@ -63,3 +64,8 @@ jobs:
       # Save test results for timing analysis
       - store_test_results:
           path: test_results
+
+      # Run security scans
+      - run:
+          name: Run brakeman security scanner
+          command: bundle exec brakeman --exit-on-warn --quiet -f plain

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'brakeman'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
       autoprefixer-rails (>= 6.0.3)
       popper_js (>= 1.12.9, < 2)
       sass (>= 3.5.2)
+    brakeman (4.3.1)
     builder (3.2.3)
     byebug (10.0.2)
     capybara (3.12.0)
@@ -248,6 +249,7 @@ DEPENDENCIES
   awesome_print
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.1.1)
+  brakeman
   byebug
   capybara (>= 2.15, < 4.0)
   chromedriver-helper


### PR DESCRIPTION
Runs the brakeman command as the final step in the build using the command line flags recommended in the [Brakeman Pro documentation](https://brakemanpro.com/docs/ci/circleci).