### PR TITLE
Add bundler-audit step to CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
           name: Run brakeman security scanner
           command: bundle exec brakeman --exit-on-warn --quiet -f plain
 
-      # Run bundler-audit  security scan
+      # Run bundler-audit security scan
       - run:
           name: Run bundler-audit to check for vulnerable dependencies
           command: bundle exec bundler-audit check --update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,12 @@ jobs:
       - store_test_results:
           path: test_results
 
-      # Run security scans
+      # Run Brakeman security scan
       - run:
           name: Run brakeman security scanner
           command: bundle exec brakeman --exit-on-warn --quiet -f plain
+
+      # Run bundler-audit  security scan
+      - run:
+          name: Run bundler-audit to check for vulnerable dependencies
+          command: bundle exec bundler-audit check --update

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'brakeman'
+  gem 'bundler-audit'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,9 @@ GEM
       sass (>= 3.5.2)
     brakeman (4.3.1)
     builder (3.2.3)
+    bundler-audit (0.6.0)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     byebug (10.0.2)
     capybara (3.12.0)
       addressable
@@ -250,6 +253,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.1.1)
   brakeman
+  bundler-audit
   byebug
   capybara (>= 2.15, < 4.0)
   chromedriver-helper


### PR DESCRIPTION
Runs the bundler-audit command as the final step in the build. The `--update` flag ensures the latest advisory DB is used.